### PR TITLE
Update src/UNL/UndergraduateBulletin/EPUB/Utilities.php

### DIFF
--- a/src/UNL/UndergraduateBulletin/EPUB/Utilities.php
+++ b/src/UNL/UndergraduateBulletin/EPUB/Utilities.php
@@ -130,10 +130,10 @@ class UNL_UndergraduateBulletin_EPUB_Utilities
 
             preg_match_all('/0?([0-9]{2,4}[A-Z]?)/', $matches[0], $course_numbers);
 
-            foreach ($course_numbers as $course_number) {
+            foreach ($course_numbers[0] as $course_number) {
                 if (!isset($courses[$matches[1]])
-                    || !in_array($course_number[0], $courses[$matches[1]])) {
-                    $courses[$matches[1]][] = $course_number[0];
+                    || !in_array($course_number, $courses[$matches[1]])) {
+                    $courses[$matches[1]][] = $course_number;
                 }
             }
         };


### PR DESCRIPTION
Fix a bug where only the first course number was being pulled in UNL_UndergraduateBulletin_EPUB::findCourses' callback.
