### PR TITLE
Finalize Request #5771

### DIFF
--- a/data/2014/majors/Political Science.xhtml
+++ b/data/2014/majors/Political Science.xhtml
@@ -48,7 +48,7 @@
 <p class="basic-text">POLS 286 and a theory course are prerequisites for POLS 400</p>
 <p class="title-1">Grade Rules</p>
 <p class="title-2">Pass/No Pass Limits</p>
-<p class="basic-text">Pass/no pass credit is not available in courses for the major except for POLS 395. Pass/no pass credit is allowed for courses in the minor, subject to College regulations. Request forms are available in the Arts and Sciences Advising Center, 107 Oldfather Hall.</p>
+<p class="basic-text">Pass/No Pass credit is not available in courses for the major except for POLS 395. Pass/No Pass credit is allowed for courses in the minor, subject to College regulations. Request forms are available in the Arts and Sciences Advising Center, 107 Oldfather Hall.</p>
 <p class="title-1">Course Level Requirement</p>
 <p class="basic-text">At least 9 hours must be at the 400 level.</p>
 <p class="content-box-h-1">REQUIREMENTS FOR MINOR OFFERED BY DEPARTMENT</p>


### PR DESCRIPTION
Updating bulletin section to reflect changes voted on and approved by the UNL Political Science Department.  Please see also the attached document outlining major changes. 

Justification for changes
1. Require majors to take 286 (Political Analysis). Make 286 a prerequisite for 400 (capstone).
   Reason: Faculty who teach 400, and even those who teach other 400-level courses, complain that students do a poor job on their research papers. Students who take 400 say they haven’t been expected or taught to do comparable research before. 286 is intended to introduce them to political science research.

Plan: Offer one section of 286 each semester. If necessary, pack students into a lecture hall and assign TA(s) for recitation sections. This would necessitate two faculty members, each offering the course once a year (or four faculty members, each offering the course once every other year). Before approving this proposal, we need a commitment from at least two faculty members to teach this course as part of their regular rotation.
1. Require majors to take 33 hours of political science, rather than the current 30.
   Reason: To accommodate the requirement to take 286. Our current hours are at the low end—very low end—for the college, so boosting them shouldn’t deter potential majors.
2. Consolidate subfields: 
   a) American and policy, to be called American Government and Public Policy.
   b) IR and comparative, to be called International Relations and Comparative Politics.

Reason: We’ve long been urged, by APR teams and the College and University administration, to streamline our major and delete some subfields. We no longer have sufficient faculty and courses to justify all four subfields addressed above in a) and b). We have just one faculty member who regularly teaches policy (but only occasionally to undergrads), one faculty member who fits squarely within comparative, and two faculty members who straddle IR and comparative. In addition, in recent years we have added the BiPsy subfield and now are proposing to add another subfield (see #6 below).
1. Delete theory subfield. 

Reason: We have only one faculty member who teaches theory (and he teaches undergrad theory just three semesters of every four). Thus the theory subfield poses a similar problem to the policy and comparative subfields, but there’s no appropriate subfield for theory to merge with.
Plan: The Undergraduate Committee believes it is important that majors and other interested students be exposed to theory. Therefore, the theory courses would continue to be offered and counted toward the major, and one theory course would continue to be required for the major. In the bulletin, the theory courses would be listed in the miscellaneous category (rather than in any subfield category), along with 286, 400, Special Topics, Independent Reading and Research, and Internships. 
1. Require theory course as a prerequisite to 400 (capstone). 

Reason: The Undergraduate Committee thinks a theory course would improve students’ critical thinking and be useful before they take the capstone course.    
1. Add new subfield, to be called Human Rights and Security. 

Reason: We’ve told the APR team and repeatedly told the administration that we’re going to emphasize HRS. We have reason to believe that we are much more likely to get new lines for a specialization in HRS, as we have been able to do for BiPsy, than we would for our traditional subfields. The administration agrees with the APR report that we need to specialize rather than be a “full-service” department. Regardless, we will never get enough faculty to be a “full-service” department (as we have not since the 1980s). Failing to build a curriculum around a second area of emphasis will effectively mean that our department has only one area of emphasis and will have real repercussions, including but not limited to no new faculty lines, decreased support for the department, and other lost opportunities. 
Plan: The idea behind this new subfield is to emphasize the intersection of human rights AND security. Existing courses that address human rights OR security would remain in the IR/comparative subfield. 
The plan is to offer an introductory course at the 100 level and, at least for the time being, a small number of courses at the 200, 300, and 400 levels, as in BiPsy. We currently have courses at the 200, 300, and 400 levels that would fit in this new subfield and commitments from faculty to teach these courses as part of their regular rotation. (Some may need to be renumbered and/or retitled, but the undergrad committee will take care of this.) We would need to create the introductory course, and we would need a commitment from at least one faculty member to teach this course as part of his or her regular rotation. 

Under proposals #3, #4, and #6, we would have two large, traditional subfields—American/policy and IR/comparative—for which we have a lot of faculty and offer a lot of courses, and we would have two smaller, newer subfields—BiPsy and HRS—which could attract more resources and help the department make its mark. Although smaller than the American/policy and IR/comparative subfields, these two newer subfields already have more faculty than policy, comparative, or theory does.  
1. Require majors to take at least three courses in two subfields, rather than the current two courses in three subfields.

Reason: Reducing the number of subfields will give students fewer subfields to choose from. Increasing the number of courses per subfield will give students somewhat more expertise in each subfield they do choose.  
