### PR TITLE
Finalize Request #5927

### DIFF
--- a/data/2014/majors/Communication Studies.xhtml
+++ b/data/2014/majors/Communication Studies.xhtml
@@ -1,67 +1,68 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
-	<head>
-		<title>Communication Studies</title>
-		<link href="template.css" rel="stylesheet" type="text/css" />
-	</head>
-	<body>
-		<div id="communication-studies">
-			<div class="story">
-				<p class="major-name"><span class="generated-style">Communication Studies</span></p>
-			</div>
-			<div class="story">
-				<p class="quick-points"><span class="quick-point-bold">COLLEGE:</span><span class="generated-style"> Arts &amp; Sciences</span></p>
-				<p class="quick-points"><span class="quick-point-bold">MAJOR:</span><span class="generated-style"> Communication Studies</span></p>
-				<p class="quick-points"><span class="quick-point-bold">DEGREES OFFERED:</span><span class="generated-style"> Bachelor of Arts or Bachelor of Science</span></p>
-				<p class="quick-points"><span class="quick-point-bold">HOURS REQUIRED:</span><span class="generated-style"> 120</span></p>
-				<p class="quick-points"><span class="quick-point-bold">MINIMUM CUMULATIVE GPA: </span><span class="generated-style">2.0 for graduation</span></p>
-				<p class="quick-points"><span class="quick-point-bold">MINOR AVAILABLE:</span><span class="generated-style"> Yes</span></p>
-				<p class="quick-points"><span class="quick-point-bold">CHIEF ADVISER:</span><span class="generated-style"> Karen Lee, Kristen Carr</span></p>
-				<p class="content-box-h-1"><span class="generated-style">DESCRIPTION</span></p>
-				<p class="faculty-list"><span class="faculty-list-bold">Chair: Dawn O. Braithwaite,</span><span class="generated-style"> 433 Oldfather</span></p>
-				<p class="faculty-list"><span class="faculty-list-bold">Director of Forensics:</span><span class="generated-style"> Aaron Duncan</span></p>
-				<p class="faculty-list"><span class="faculty-list-bold">Professors: </span><span class="generated-style">Braithwaite, Krone, R. Lee, Seiler</span></p>
-				<p class="faculty-list"><span class="faculty-list-bold">Associate Professors:</span><span class="generated-style"> Kellas, Soliz</span></p>
-				<p class="faculty-list"><span class="faculty-list-bold">Assistant Professors:</span><span class="generated-style"> Lucas, Pfister</span></p>
-				<p class="faculty-list"><span class="faculty-list-bold">Assistant Professor of Practice:</span><span class="generated-style"> K. Lee</span></p>
-				<p class="basic-text"><span class="generated-style">Communication studies is a social science and humanistic field of study, research, and application. The mission of the Department of Communication Studies is to examine human symbolic activity as it shapes and is shaped by relationships, institutions, and societies. This work concerns how, why, and with what effects people communicate through verbal and nonverbal messages. Through research, teaching, and service, the Department devotes particular attention to understanding the ways in which communication erodes and sustains collaboration within and among local, national, and global communities.</span></p>
-				<p class="basic-text"><span class="generated-style">Communication competencies are among those most highly desired in professional, personal, organizational, and civic arenas. Additionally, a major in Communication Studies goes beyond learning communication skills by fostering a world view that demonstrates a commitment to communication, collaboration, and community. Communication Studies majors go on to careers in sales, marketing, human resources, customer service, nonprofit management, event planning, fund raising, public relations, management, and government, to name just a few. Majors also go on to graduate school and law school.</span></p>
-				<p class="title-2"><span class="generated-style">University Debate and Forensics</span></p>
-				<p class="basic-text"><span class="generated-style">The University of Nebraska–Lincoln offers a nationally recognized debate and forensics program of participation in campus and intercollegiate debate, public speaking, and interpretation events. The program gives students the opportunity to compete at the local, state, regional, and national level. No previous debate or speech experience is required. All students who are in good standing may take part in intercollegiate debate and forensics.</span></p>
-				<p class="header-paragraph"><span class="header-paragraph-title">Graduate Work.</span><span class="generated-style"> Graduate programs leading to the master of arts and doctor of philosophy degrees are offered in the department. </span><span class="basic-text-ital">A master of arts specialization in marketing, communication studies, and advertising is also offered by the department.</span><span class="generated-style"> A detailed description of these programs appears in the Graduate Studies Bulletin.</span></p>
-				<p class="content-box-h-1"><span class="generated-style">MAJOR REQUIREMENTS</span></p>
-				<p class="title-1"><span class="generated-style">Specific Major Requirements</span></p>
-				<p class="basic-text"><span class="generated-style">All prospective majors must consult and register with a departmental chief adviser. Majors are expected to meet regularly with their adviser. An approved program of study must be filed at the time students declare the major or within the first 12 hours of course work in the major. In order to graduate with a communication studies major, students must have an approved program of study. The minimum number of hours for a major in communication studies is 36. The 36-hour requirement must include the following:</span></p>
-				<p class="numbered-list"><span class="generated-style">1. Majors must complete one of the following: COMM 109, COMM 209, COMM 212 or COMM 286.</span></p>
-				<p class="numbered-list"><span class="generated-style">2. Majors must complete both COMM 200 and COMM 201. These courses should be completed within the first twelve hours in communication studies of a student’s program.</span></p>
-				<p class="numbered-list"><span class="generated-style">3. Majors must complete COMM 495.</span></p>
-				<p class="header-paragraph"><span class="header-paragraph-title">Program Assessment.</span><span class="generated-style"> In order to assist the department in evaluating the effectiveness of its programs, majors will be required to complete an assessment of the major. This assessment will be implemented in the communication studies capstone course: COMM 495.</span></p>
-				<p class="basic-text"><span class="generated-style">Results of participation in this assessment activity will in no way affect a student’s GPA, but could prevent or delay graduation if the assessment is not completed as required.</span></p>
-				<p class="title-1"><span class="generated-style">Minor Requirements</span></p>
-				<p class="basic-text"><span class="generated-style">A communication studies major must have either an approved Plan A minor or two approved Plan B minors. An approved individualized program of studies of 24 hours can also be used to meet the minor requirement. A departmental adviser must approve the minor.</span></p>
-				<p class="content-box-h-1"><span class="generated-style">ADDITIONAL MAJOR REQUIREMENTS</span></p>
-				<p class="title-1"><span class="generated-style">Prerequisite Requirements/Rules</span></p>
-				<p class="basic-text"><span class="generated-style">COMM 200 and COMM 201 must be completed before a student can enroll in any 400-level course. </span></p>
-				<p class="title-1"><span class="generated-style">Grade Rules </span></p>
-				<p class="title-2"><span class="generated-style">C- and D Grades</span></p>
-				<p class="basic-text"><span class="generated-style">A grade of C or above is required for all courses in the major.</span></p>
-				<p class="title-2"><span class="generated-style">Pass/No Pass Limits</span></p>
-				<p class="basic-text"><span class="generated-style">Availability of Pass/No Pass credit in COMM courses is at the discretion of the course director and/or instructor of the course. Although the department discourages Pass/No Pass credit for majors, up to 6 hours of Pass/No Pass credit may be applied to the major requirements. Up to 6 hours Pass/No Pass credit is permitted toward the minor, subject to the approval of the department granting the major.</span></p>
-				<p class="title-1"><span class="generated-style">Course Level Requirement</span></p>
-				<p class="basic-text"><span class="generated-style">A minimum of 21 hours must be taken in communication studies courses at or above the 300 level, excluding COMM 390 and COMM 490. Of the 21 hours, at least 9 must be at the 400 level. COMM 200 and COMM 201 must be completed before a student can enroll in any 400-level course. COMM 490 cannot be used to meet this requirement.</span></p>
-				<p class="title-1"><span class="generated-style">Extended Education, Independent Study Rules, Internship Credit Rules</span></p>
-				<p class="basic-text"><span class="generated-style">The department encourages qualified students to enroll in internship, independent study, and education abroad experiences in order to supplement classroom experiences. However, non of these is a substitute for classroom experiences. No more than 3 hours of internship, independent study, or education abroad credits may count toward the 36-hour requirement in the major.</span></p>
-				<p class="content-box-h-1"><span class="generated-style">REQUIREMENTS FOR MINOR OFFERED BY DEPARTMENT</span></p>
-				<p class="basic-text"><span class="generated-style">A communication studies major must have either an approved Plan A minor or two approved Plan B minors. An approved individualized program of study of 24 hours can also be used to meet the minor requirement. A departmental adviser must approve the minor. </span></p>
-				<p class="header-paragraph"><span class="header-paragraph-title">Plan A.</span><span class="generated-style"> This minor consists of a minimum of 18 hours in communication studies courses with at least 9 hours at or above the 300 level. The 18-hour requirement must include the following:</span></p>
-				<p class="numbered-list"><span class="generated-style">1. Plan A minors must complete either COMM 200 or COMM 201.</span></p>
-				<p class="numbered-list"><span class="generated-style">2. Plan A minors must complete either COMM 109, COMM 209, COMM 212, or COMM 286.</span></p>
-				<p class="numbered-list"><span class="generated-style">3. A minimum of 9 hours must be taken in communication studies classes at or above the 300 level excluding COMM 390 and COMM 490.</span></p>
-				<p class="numbered-list"><span class="generated-style">4. Of the 9 hours, at least 3 must be at the 400 level. COMM 200 or COMM 201 must be completed before a student can enroll in any 400-level course. COMM 490 cannot be used to meet this requirement.</span></p>
-				<p class="numbered-list"><span class="generated-style">5. The department encourages qualified students to enroll in internship, independent study, and study abroad experiences in order to supplement classroom experiences. However, none of these is a substitute for classroom experiences. No more than 3 hours of internship, independent study, or study abroad credits may count toward the 36-credit-hour requirement in the major. Please refer to items 4 and 5 above. .</span></p>
-				<p class="header-paragraph"><span class="header-paragraph-title">Plan B.</span><span class="generated-style"> 12 hours of communication studies courses with at least 9 hours at or above the 200 level, excluding COMM 390 or COMM 490. A maximum of 3 hours of internship or independent study may apply to the 12-hour requirement.</span></p>
-			</div>
-		</div>
-	</body>
+    <head>
+        <title>Communication Studies 14-15.xhtml</title>
+        <link href="template.css" rel="stylesheet" type="text/css" />
+    </head>
+    <body>
+        <div id="communication-studies-14-15">
+            <div class="generated-style">
+                <p class="major-name">Communication Studies</p>
+            </div>
+            <div class="generated-style">
+                <p class="quick-points"><span class="quick-point-bold">COLLEGE:</span> Arts & Sciences</p>
+                <p class="quick-points"><span class="quick-point-bold">MAJOR:</span> Communication Studies</p>
+                <p class="quick-points"><span class="quick-point-bold">DEGREE OFFERED:</span> Bachelor of Arts or Bachelor of Science</p>
+                <p class="quick-points"><span class="quick-point-bold">HOURS REQUIRED:</span> 120</p>
+                <p class="quick-points"><span class="quick-point-bold">MINIMUM CUMULATIVE GPA:</span> 2.0 for graduation</p>
+                <p class="quick-points"><span class="quick-point-bold">MINOR AVAILABLE:</span> Yes</p>
+                <p class="quick-points"><span class="quick-point-bold">CHIEF ADVISER:</span> Karen Lee, Kristen Carr</p>
+<p class="content-box-h-1">DESCRIPTION</p>
+<p class="faculty-list"><span class="faculty-list-bold">Chair: Dawn O. Braithwaite,</span><span class="generated-style"> 433 Oldfather</span></p>
+<p class="faculty-list"><span class="faculty-list-bold">Director of Forensics:</span><span class="generated-style"> Aaron Duncan</span></p>
+<p class="faculty-list"><span class="faculty-list-bold">Professors: </span><span class="generated-style">Braithwaite, Krone, R. Lee, Seiler</span></p>
+<p class="faculty-list"><span class="faculty-list-bold">Associate Professors:</span><span class="generated-style"> Kellas, Soliz</span></p>
+<p class="faculty-list"><span class="faculty-list-bold">Assistant Professors:</span><span class="generated-style">  Pfister, Woods</span></p>
+<p class="faculty-list"><span class="faculty-list-bold">Assistant Professor of Practice:</span><span class="generated-style"> K. Lee</span></p>
+<p class="basic-text"><span class="generated-style">Communication studies is a social science and humanistic field of study, research, and application. The mission of the Department of Communication Studies is to examine human symbolic activity as it shapes and is shaped by relationships, institutions, and societies. This work concerns how, why, and with what effects people communicate through verbal and nonverbal messages. Through research, teaching, and service, the Department devotes particular attention to understanding the ways in which communication erodes and sustains collaboration within and among local, national, and global communities.</span></p>
+<p class="basic-text"><span class="generated-style">Communication competencies are among those most highly desired in professional, personal, organizational, and civic arenas. Additionally, a major in Communication Studies goes beyond learning communication skills by fostering a world view that demonstrates a commitment to communication, collaboration, and community. Communication Studies majors go on to careers in sales, marketing, human resources, customer service, nonprofit management, event planning, fund raising, public relations, management, and government, to name just a few. Majors also go on to graduate school and law school.</span></p>
+<p class="title-2"><span class="generated-style">University Debate and Forensics</span></p>
+<p class="basic-text"><span class="generated-style">The University of Nebraska–Lincoln offers a nationally recognized debate and forensics program of participation in campus and intercollegiate debate, public speaking, and interpretation events. The program gives students the opportunity to compete at the local, state, regional, and national level. No previous debate or speech experience is required. All students who are in good standing may take part in intercollegiate debate and forensics.</span></p>
+<p class="header-paragraph"><span class="header-paragraph-title">Graduate Work.</span><span class="generated-style"> Graduate programs leading to the master of arts and doctor of philosophy degrees are offered in the department. </span><span class="basic-text-ital">A master of arts specialization in marketing, communication studies, and advertising is also offered by the department.</span><span class="generated-style"> A detailed description of these programs appears in the Graduate Studies Bulletin.</span></p>
+<p class="content-box-h-1">MAJOR REQUIREMENTS</p>
+<p class="title-1"><span class="generated-style">Specific Major Requirements</span></p>
+<p class="basic-text"><span class="generated-style">All prospective majors must consult and register with a departmental chief adviser. Majors are expected to meet regularly with their adviser. An approved program of study must be filed at the time students declare the major or within the first 12 hours of course work in the major. In order to graduate with a communication studies major, students must have an approved program of study. The minimum number of hours for a major in communication studies is 36. The 36-hour requirement must include the following:</span></p>
+<p class="numbered-list"><span class="generated-style">1. Majors must complete one of the following: COMM 109, COMM 205, COMM 209, COMM 212, COMM 220, COMM 286, or COMM 295.</span></p>
+<p class="numbered-list"><span class="generated-style">2. Majors must complete both COMM 101 and COMM 201. These courses should be completed within the first twelve hours in communication studies of a student’s program.</span></p>
+<p class="numbered-list">3. Majors must complete two of three 200-level foundational courses. See major adviser for eligible course options.<span class="generated-style"></span><span class="generated-style"></span></p>
+<p class="numbered-list"><span class="generated-style">4. Majors must complete COMM 495.</span></p>
+<p class="header-paragraph"><span class="header-paragraph-title">Program Assessment.</span><span class="generated-style"> In order to assist the department in evaluating the effectiveness of its programs, majors will be required to complete an assessment of the major. This assessment will be implemented in the communication studies capstone course: COMM 495.</span></p>
+<p class="basic-text"><span class="generated-style">Results of participation in this assessment activity will in no way affect a student’s GPA, but could prevent or delay graduation if the assessment is not completed as required.</span></p>
+<p class="title-1"><span class="generated-style">Minor Requirements</span></p>
+<p class="basic-text"><span class="generated-style">A communication studies major must have either an approved Plan A minor or two approved Plan B minors. An approved individualized program of studies of 24 hours can also be used to meet the minor requirement. A departmental adviser must approve the minor.</span></p>
+<p class="content-box-h-1">ADDITIONAL MAJOR REQUIREMENTS</p>
+<p class="title-1"><span class="generated-style">Prerequisite Requirements/Rules</span></p>
+<p class="basic-text"><span class="generated-style">COMM 101 and COMM 201 must be completed before a student can enroll in any 400-level course. </span></p>
+<p class="title-1"><span class="generated-style">Grade Rules </span></p>
+<p class="title-2"><span class="generated-style">C- and D Grades</span></p>
+<p class="basic-text"><span class="generated-style">A grade of C or above is required for all courses in the major.</span></p>
+<p class="title-2"><span class="generated-style">Pass/No Pass Limits</span></p>
+<p class="basic-text"><span class="generated-style">Availability of Pass/No Pass credit in COMM courses is at the discretion of the course director and/or instructor of the course. Although the department discourages Pass/No Pass credit for majors, up to 6 hours of Pass/No Pass credit may be applied to the major requirements. Up to 6 hours Pass/No Pass credit is permitted toward the minor, subject to the approval of the department granting the major.</span></p>
+<p class="title-1"><span class="generated-style">Course Level Requirement</span></p>
+<p class="basic-text"><span class="generated-style">A minimum of 21 hours must be taken in communication studies courses at or above the 300 level, excluding COMM 390 and COMM 490. Of the 21 hours, at least 9 must be at the 400 level. COMM 101 and COMM 201 must be completed before a student can enroll in any 400-level course. COMM 490 cannot be used to meet this requirement.</span></p>
+<p class="title-1"><span class="generated-style">Extended Education, Independent Study Rules, Internship Credit Rules</span></p>
+<p class="basic-text"><span class="generated-style">The department encourages qualified students to enroll in internship, independent study, and education abroad experiences in order to supplement classroom experiences. However, non of these is a substitute for classroom experiences. No more than 3 hours of internship, independent study, or education abroad credits may count toward the 36-hour requirement in the major.</span></p>
+<p class="content-box-h-1">REQUIREMENTS FOR MINOR OFFERED BY DEPARTMENT</p>
+<p class="basic-text"><span class="generated-style">A communication studies major must have either an approved Plan A minor or two approved Plan B minors. An approved individualized program of study of 24 hours can also be used to meet the minor requirement. A departmental adviser must approve the minor. </span></p>
+<p class="header-paragraph"><span class="header-paragraph-title">Plan A.</span><span class="generated-style"> This minor consists of a minimum of 18 hours in communication studies courses with at least 9 hours at or above the 300 level. The 18-hour requirement must include the following:</span></p>
+<p class="numbered-list"><span class="generated-style">1. Plan A minors must complete either COMM 101 or COMM 201.</span></p>
+<p class="numbered-list"><span class="generated-style">2. Plan A minors must complete either COMM 109, COMM 205, COMM 209, COMM 212, COMM 220, COMM 286, or COMM 295.</span></p>
+<p class="numbered-list"><span class="generated-style">3. A minimum of 9 hours must be taken in communication studies classes at or above the 300 level excluding COMM 390 and COMM 490.</span></p>
+<p class="numbered-list"><span class="generated-style">4. Of the 9 hours, at least 3 must be at the 400 level. COMM 101 or COMM 201 must be completed before a student can enroll in any 400-level course. COMM 490 cannot be used to meet this requirement.</span></p>
+<p class="numbered-list"><span class="generated-style">5. The department encourages qualified students to enroll in internship, independent study, and study abroad experiences in order to supplement classroom experiences. However, none of these is a substitute for classroom experiences. No more than 3 hours of internship, independent study, or study abroad credits may count toward the 36-credit-hour requirement in the major. Please refer to items 4 and 5 above. .</span></p>
+<p class="header-paragraph"><span class="header-paragraph-title">Plan B.</span><span class="generated-style"> 12 hours of communication studies courses with at least 9 hours at or above the 200 level, excluding COMM 390 or COMM 490. A maximum of 3 hours of internship or independent study may apply to the 12-hour requirement.</span></p>
+            </div>
+        </div>
+    </body>
 </html>


### PR DESCRIPTION
The changes to the major include a new introductory course in communication, COMM 101: Communication in the 21st Century. This course was recently approved by the College Curriculum Committee and was designed to provide students with an overview of the field of communication studies and the ways in which communication can help address important challenges and opportunities in modern society. We have substituted COMM 101 for COMM 200 which will no longer be required of majors or minors. 

We have also added in the requirement of two (out of three options) foundational 200-level courses to ensure that students have a foundation in one of the three core competency objectives: Advocate, Negotiate, and Relate. One of these courses is an approved existing course. The other two courses are being designed and should be approved courses by 2014-2015 AY. Therefore, we want students to begin taking them, but because we do not yet have approved course numbers we made requirement #3 purposefully broad for this year's bulletin.
