### PR TITLE
Finalize Request #5907

### DIFF
--- a/data/2014/majors/Computer Science.xhtml
+++ b/data/2014/majors/Computer Science.xhtml
@@ -30,7 +30,7 @@
 <p class="faculty-list"><span class="faculty-list-bold">FAX:</span> 402-472-7767</p>
 <p class="faculty-list">http://cse.unl.edu</p>
 <p class="faculty-list"><span class="faculty-list-bold">email:</span> info@cse.unl.edu</p>
-<p class="basic-text">The UNL Department of Computer Science and Engineering (CSE) offers Nebraska’s only comprehensive program of higher education, research, and service outreach in computer science and computer engineering.</p>
+<p class="basic-text">The UNL Department of Computer Science and Engineering (CSE) offers Nebraskas only comprehensive program of higher education, research, and service outreach in computer science and computer engineering.</p>
 <p class="basic-text">The CSE department offers a challenging baccalaureate degree program in computer science that prepares graduates for professional practice as computer scientists, provides the basis for advanced studies in the field, and establishes a foundation for life-long learning and achievement. The BS degree in computer science is accredited by the Computing Accreditation Commission of ABET.</p>
 <p class="basic-text">Consistent with these goals, the computer science baccalaureate program develops:</p>
 <ul>
@@ -77,7 +77,7 @@
 </ul>
 <p class="header-paragraph"><span class="basic-text-bold">NOTE:</span> Bold face type indicates a lab course or that a lab is included with the course.</p>
 <p class="header-paragraph"><span class="header-paragraph-title">Program Assessment.</span> In order to assist the department in evaluating the effectiveness of its programs, majors will be required in their senior year to complete a written exit survey.</p>
-<p class="basic-text">Results of participation in these assessment activities will in no way affect a student’s GPA or graduation.</p>
+<p class="basic-text">Results of participation in these assessment activities will in no way affect a students GPA or graduation.</p>
 <p class="title-1">Tracks/Options/Concentrations/Emphases Requirements</p>
 <p class="title-2">Focus</p>
 <p class="basic-text">A computer science major has the option of declaring a Focus in one of the areas listed below. Students who, in addition to meeting all computer science requirements listed above, receive a grade of C or better in each of three technical elective courses from one focus area below will receive a notice from the Department of Computer Science and Engineering stating that they received the degree bachelor of science in computer science with a Focus in their chosen area.</p>


### PR DESCRIPTION
Currently, our students satisfy ACE8 requirement by picking up 1 hour from CSCE230 and then 2 hours from CSCE486. As part of the ACE re-certification, we want to shift all three ACE8 hours into CSCE486. This creates the need to expand CSCE486 to 3 hours. We will use the one hour from the reduction of Math 107 last year to compensate for this 1 additional hour, resulting in no net gain.
