### PR TITLE
Finalize Request #5824

### DIFF
--- a/data/2014/majors/Womens & Gender Studies.xhtml
+++ b/data/2014/majors/Womens & Gender Studies.xhtml
@@ -11,8 +11,8 @@
                 <p class="major-name">Women's & Gender Studies</p>
             </div>
             <div class="generated-style">
-                <p class="quick-points"><span class="quick-point-bold">COLLEGE:</span> Arts & Sciences</p>
-                <p class="quick-points"><span class="quick-point-bold">MAJOR:</span> Women's & Gender Studies</p>
+                <p class="quick-points"><span class="quick-point-bold">COLLEGE:</span> Arts &amp; Sciences</p>
+                <p class="quick-points"><span class="quick-point-bold">MAJOR:</span> Women's &amp; Gender Studies</p>
                 <p class="quick-points"><span class="quick-point-bold">DEGREE OFFERED:</span> Bachelor of Arts or Bachelor of Science</p>
                 <p class="quick-points"><span class="quick-point-bold">HOURS REQUIRED:</span> 120</p>
                 <p class="quick-points"><span class="quick-point-bold">MINIMUM CUMULATIVE GPA:</span> 2.0 for graduation</p>
@@ -60,7 +60,7 @@
 <p class="requirement-sec-2">ENGL 414/WMNS 414 Women's Literature</p>
 <p class="requirement-sec-2">ENGL 414B/WMNS 414B Modern &amp; Contemporary Women Writers</p>
 <p class="requirement-sec-2">ENGL 475A/WMNS 475A Rhetorical Theory: Rhetoric of Women Writers</p>
-<p class="requirement-sec-2"><span>FREN/</span>WMNS 388<span>Body Language: Love, Politics, and the Self in French Literature</span></p>
+<p class="requirement-sec-2"><span>FREN 388/ENGL 388/MRST 388/</span>WMNS 388 <span>Body Language: Love, Politics, and the Self in French Literature</span></p>
 <p class="requirement-sec-2">JUDS 340/RELG 340/WMNS 340 Women in the Biblical World</p>
 <p class="requirement-sec-2">PHIL 218/WMNS 218 Philosophy of Feminism</p>
 <p class="requirement-sec-2 requirement-sec-2-override"><span class="no-style-override">*/</span>**WMNS 201 <span class="no-style-override">Introduction</span> to <span class="no-style-override">Lesbian, Gay, Bisexual, Transgender, Queer</span>/Sexuality Studies</p>


### PR DESCRIPTION
We have changed all the language to read "hours" not "credits" to maintain consistency within our bulletin listing as well as with the language of the undergraduate bulletin more generally.

Removal of WMNS 211 (Applying Social Justice to LGBTQA Programs & Services):
The WGS Curriculum Committee has chosen to remove this course. Students can choose from existing WGS courses (WMNS 210: Activism and Feminist Communities and WMNS 4/897: Internship in WGS) to pursue internships in LGBTQA organizations.

Addition of WMNS 291 (Special Topics in Women's & Gender Studies):
Women's & Gender Studies has long been wanting to develop more 200-level courses, and special topics courses are important ways for programs/departments to do so. Currently, our only special topics courses are 400/800 or 800 only. This creates problems when looking to develop lower level courses. Thus by creating a 200-level special topics course, we can grow our curriculum. Should one of these special topics course continue to be offered on a regular basis, we would then propose it formally as its own course with its own title and number.

Addition of WMNS 391 (Special Topics in Women's & Gender Studies):
Women's & Gender Studies has long been wanting to develop more 300-level courses, and special topics courses are important ways for program/departments to do so. Currently, our only special topics courses are 400/800 or 800 only. This creates problems when looking to develop lower level courses. Thus by creating a 300-level special topics course, we can grow our curriculum. Should one of these special topics course continue to be offered on a regular basis, we would then propose it formally as its own course with its own title and number.

Addition of existing course -- PSYC 471/CYAF 471/EDPS 471/SOCI 471 (Human Sexuality & Society):
Given the topic of the course, the WGS Curriculum Committee felt it meets the aims of the Women's & Gender Studies Program. It also fulfills our Social Sciences requirement.
