### PR TITLE
Finalize Request #6584

### DIFF
--- a/data/2014/majors/Japanese Minor.xhtml
+++ b/data/2014/majors/Japanese Minor.xhtml
@@ -14,7 +14,7 @@
                 <p class="quick-points"><span class="quick-point-bold">COLLEGE:</span> Arts &amp; Sciences</p>
                 <p class="quick-points"><span class="quick-point-bold">MAJOR:</span> Japanese Minor</p>
                 <p class="quick-points"><span class="quick-point-bold">DEGREE OFFERED:</span> Minor only</p>
-                <p class="quick-points"><span class="quick-point-bold">HOURS REQUIRED:</span> 6-22</p>
+                <p class="quick-points"><span class="quick-point-bold">HOURS REQUIRED:</span> 12</p>
                 <p class="quick-points"><span class="quick-point-bold">MINIMUM CUMULATIVE GPA:</span> </p>
                 <p class="quick-points"><span class="quick-point-bold">MINOR AVAILABLE:</span> Yes</p>
                 <p class="quick-points"><span class="quick-point-bold">CHIEF ADVISER:</span> Ikuho Amano</p>
@@ -47,15 +47,15 @@
 <p class="content-box-h-1">REQUIREMENTS FOR MINOR OFFERED BY DEPARTMENT</p>
 <p class="header-paragraph"><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span></p>
 
-<p class="title-2">12 hours of courses numbered 300 or above. </p>
+<p>12 hours of courses numbered 300 or above</p>
 <p>• 9 hours from 300 level JAPN courses (JAPN 301 Advanced Conversation and Composition I, JAPN 302 Advanced Conversation and Composition II, JAPN 303 Advanced Grammar and Reading I, JAPN 304 Advanced Grammar and Reading II, JAPN 307 Business Japanese I, JAPN 308 Business Japanese II, JAPN 331 Introduction to Japanese Film);</p>
 <p>• 3 additional hours. Three hours may be from:</p>
-<p>- a 300 or 400 level JAPN course (JAPN 331 Introduction to Japanese Film or JAPN 483<strong> </strong>Modern Japanese Literature and Culture in Translation)</p>
-<p>- from a 300 or 400 level MODL course (MODL 398 or MODL 498 Special Topic)</p>
-<p>- Specific courses in other Departments that may be used to fulfill this requirement are: </p>
-<p>ANTH 366 People and Cultures of East Asia</p>
-<p>ARCH 450 Survey of Asian Architecture</p>
-<p>POLS 464 Political Economy of the Asia-Pacific</p>
+<p class="requirement-sec-3">- a 300 or 400 level JAPN course (JAPN 331 Introduction to Japanese Film or JAPN 483<strong> </strong>Modern Japanese Literature and Culture in Translation)</p>
+<p class="requirement-sec-3">- from a 300 or 400 level MODL course (MODL 398 or MODL 498 Special Topic)</p>
+<p class="requirement-sec-3">- Specific courses in other Departments that may be used to fulfill this requirement are: </p>
+<p>ANTH 366<span class="requirement-sec-4"> People and Cultures of East Asia</span></p>
+<p>ARCH 450<span class="requirement-sec-4"> Survey of Asian Architecture</span></p>
+<p>POLS 464<span class="requirement-sec-4"> Political Economy of the Asia-Pacific</span></p>
 
 
 


### PR DESCRIPTION
• Expanding the minor by 6 hours brings more breadth to the minor, as the new plan encompasses courses on literature, culture, film, and other courses related to Japanese Studies. 

• Invigorates students' proficiency in Japanese as a less-commonly-taught language and cultural literacy. 

• Develops cross-listed courses and establish ties with other departments. 

• Plan B minor is eliminated.
