### PR TITLE
Finalize Request #6597

### DIFF
--- a/data/2014/majors/Jewish Studies Minor.xhtml
+++ b/data/2014/majors/Jewish Studies Minor.xhtml
@@ -31,13 +31,11 @@
 <p class="requirement-sec-3">JUDS 205 Introduction to the Hebrew Bible/Old Testament (RELG 205)</p>
 <p class="requirement-sec-3">JUDS 219 Introduction to Jewish History (HIST 219/RELG 219)</p>
 <p> JUDS 333 Jews in the Modern World (HIST 333/RELG 333)</p>
-<p>JUDS 339 The Holocaust (HIST 339)</p>
-<p> JUDS 350 Literature of Judaism</p>
+<p class="requirement-sec-3">JUDS 339 The Holocaust (HIST 339)</p>
+<p> <span class="requirement-sec-3">JUDS 350</span> Literature of Judaism</p>
 
-<p> b. Additional three courses (9 hours) from the elective course list below. </p>
-
-
-<p>Credits earned using the Pass/No Pass option do not count toward this minor.</p>
+<p> b. <span class="requirement-sec-1">Additional</span> three courses (9<span class="requirement-sec-1"> hours</span>) from the elective course list below. </p>
+<p><span class="header-paragraph-title">Credits earned using the Pass/No Pass option do not count toward this minor.</span></p>
 <p class="title-2">Elective Courses</p>
 
 <p class="list">CLAS 409 Religion of Late Western Antiquity (HIST 409/RELG 409)</p>


### PR DESCRIPTION
Updating bulletin section.

The Executive Committee of the Harris Center for Judaic Studies concluded that the list of core courses was too restrictive, and should be increased from 2 to 5, from which students may choose. It also felt that 18 hours for the Minor were too many, given the limited number of faculty available to teach in this area in any given year; this made it too difficult to complete the Minor in a reasonable time frame.

NOTE: The minor will remain at 18 hours.
