### PR TITLE
Finalize Request #6547

### DIFF
--- a/data/2014/majors/French (ASC).xhtml
+++ b/data/2014/majors/French (ASC).xhtml
@@ -51,6 +51,8 @@
 <p class="requirement-sec-4">-12 hours at the 400 level; 6 hours at the 400 level must be in literature courses</p>
 <p class="header-paragraph"><span class="header-paragraph-title">Program Assessment.</span> In order to assist the department in evaluating the effectiveness of its programs, majors will be required to assemble and maintain a portfolio. In their junior year, majors will be assigned a faculty adviser who will inform students of the required contents of the portfolio, deadlines and procedures. During their last semester, French majors will be required to provide oral and written assessment for their portfolios. They will provide a writing sample at the beginning and end of their program of study, and their oral proficiency will also be assessed twice. They will be evaluated in such a way that corresponds to the ACTFL proficiency standards.  </p>
 <p class="basic-text">Results of participation in this assessment activity will in no way affect a student’s GPA or graduation.</p>
+<p class="title-1">Minor Requirements</p>
+<p class="basic-text">A minor is required and may be taken in any area.</p>
 <p class="content-box-h-1">ADDITIONAL MAJOR REQUIREMENTS</p>
 <p class="title-1">Grade Rules</p>
 <p class="title-2">Pass/No Pass Limits</p>


### PR DESCRIPTION
Expanding the major by three hours will increase our students' breath of knowledge in French and Francophone literature, culture, and history. Reflecting the national trend away from a strictly century-based curriculum, the section will take advantage of the extra credits to build a curriculum invested in exposing students to a wider range of literary and cultural texts. Students will be more conversant in topics, texts, and questions that are important to French and Francophone society, which will increase the applicability and the relevance of the major within a global context.

Because the extra three credits will take place at the 400 level, students will strengthen their writing and speaking skills at an advanced level. They will apply their skills by means of discussion, critical thinking, and analytical writing, all of which will ensure better outcomes for majors and will provide useful tools for any future career. 

The French section will also continue to allow students to complete 3 credit hours in a culture class taught in English, to be taken either from the French section's own offerings, or from interdisciplinary courses offered in MLL.

Despite the proposed changes, it will be possible to complete the French major as part of a four-year plan (beginning with FREN 101 and following the accelerated sequence by taking FREN 210). Here is a basic outline (with a slash separating fall and spring semesters. Year 1: 101 / 102 Year 2: 210/ 203, 204, extra 300-class (can be in English, could also be another semester). Year 3: 301, 303, / 302, 304; Year4: 4xx, 4xx,/ 4xx, 4xx
