### PR TITLE
Finalize Request #6955

### DIFF
--- a/data/2014/majors/Arabic Minor.xhtml
+++ b/data/2014/majors/Arabic Minor.xhtml
@@ -67,6 +67,9 @@
 <p class="requirement-sec-3">RELG 318 Islam in the Modern World</p>
 <p class="requirement-sec-3">WMNS 408/808 Cross-cultural Mentoring I (ANTH 408/NUTR 408) <span class="requirement-ital">(</span><span class="requirement-ital">cases should be from an Arabic background)</span></p>
 <p class="requirement-sec-3"> WMNS 409/809 Cross-cultural Mentoring II (ANTH 409/NUTR 409)</p>
+<p class="title-1">Grade Rules</p>
+<p class="title-2">Pass/No Pass</p>
+<p class="basic-text">No courses in the department may be taken by students minoring in Arabic for Pass/No Pass credit.</p>
 
             </div>
         </div>


### PR DESCRIPTION
-   Increasing number of student enrolment in the Arabic classes. 

Fall 2013:      ARAB 101 =33 students
                      ARAB 202 =14 students  
Spring 2014: ARAB 102 = 28 students 
                      ARAB 202 = 15
-   Proficiency in Arabic can’t be established without a clear plan that requires at least 3 years of studying Arabic.
-   The desire to continue studying Arabic for three years to get a minor in Arabic studies as expressed by current students. (surveys)
-   Minors of Arabic Studies are offered by ALL Big Ten universities except for the University of Nebraska-Lincoln and the University of Wisconsin- Madison.
-   The suggested long list of classes related to Arabic and Islamic culture that can count towards the Minor give students an appealing variety of options to choose from. 
