### PR TITLE
Fix issue with course numbers being turned into leader format

### DIFF
--- a/src/UNL/UndergraduateBulletin/EPUB/Utilities.php
+++ b/src/UNL/UndergraduateBulletin/EPUB/Utilities.php
@@ -81,7 +81,7 @@ class UNL_UndergraduateBulletin_EPUB_Utilities
     public static function addLeaders($html)
     {
         $html = preg_replace('/<br \/>/', ' ', $html);
-        $html = preg_replace('/<p class="(requirement-sec-[1-4](?:\-(?:ledr|note))?)"[^>]*>(.*)\s([\d]{1,3}(?:\-[\d]{1,3})?)[\s]*<\/p>/', '<p class="$1"><span class="req_desc">$2</span><span class="leader"></span><span class="req_value">$3</span></p>', $html);
+        $html = preg_replace('/<p class="(requirement-sec-[1-4](?:\-(?:ledr|note))?)"[^>]*>(.*)\s([\d]{1,2}(?:\-[\d]{1,3})?)[\s]*<\/p>/', '<p class="$1"><span class="req_desc">$2</span><span class="leader"></span><span class="req_value">$3</span></p>', $html);
         $html = preg_replace('/<p class="(abbreviations-list)"[^>]*>(((\sor\s)?[^\s]+)+)\s([^<]*)(<span.*>.*<\/span>)?<\/p>/', '<p class="$1"><span class="req_desc">$2</span><span class="leader"></span><span class="req_value">$5 $6</span></p>', $html);
         return $html;
     }

--- a/tests/EPUB_Utilities/leaders.phpt
+++ b/tests/EPUB_Utilities/leaders.phpt
@@ -40,6 +40,12 @@ $html = UNL_UndergraduateBulletin_EPUB_Utilities::addLeaders($string);
 
 $test->assertEquals('<p class="requirement-sec-3-ledr"><span class="req_desc">ACE 6. EDPS 251 <span class="requirement-ital">(Pre-Professional Education Requirement)</span></span><span class="leader"></span><span class="req_value">3</span></p>', $html, 'leader with html - third level');
 
+$string = '<p class="requirement-sec-2">6 hours of SPAN 305 and SPAN 317</p>';
+
+$html = UNL_UndergraduateBulletin_EPUB_Utilities::addLeaders($string);
+
+$test->assertEquals($string, $html, 'no leaders on course numbers');
+
 ?>
 ===DONE===
 --EXPECT--


### PR DESCRIPTION
Credit hour spans must start with at most a 2-digit number to be followed
by a 3-digit number
