### PR TITLE
Finalize Request #7679

### DIFF
--- a/data/2015/majors/Classics & Religious Studies.xhtml
+++ b/data/2015/majors/Classics & Religious Studies.xhtml
@@ -69,7 +69,5 @@
 <p class="basic-text">A minimum of 18 hours of courses with the prefix RELG, including at least 3 hours at the 100 level, 3 hours at the 200 level, and 3 hours at the 300 or 400 level. The student may count up to 3 hours above the 199 level in Greek, Latin, Hebrew or Arabic toward the Religious Studies minor.</p>
             </div>
         </div>
-            </div>
-        </div>
     </body>
 </html>


### PR DESCRIPTION
Updating bulletin section.
On 10/13/14 the Classics and Religious Studies voted unanimously to require that all CRS majors on the Religious Studies track take RELG 350 so that they have at least one theory/methodology course in the discipline.  
