### PR TITLE
Finalize Request #7612

### DIFF
--- a/data/2015/majors/Economics (ASC).xhtml
+++ b/data/2015/majors/Economics (ASC).xhtml
@@ -2,11 +2,11 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <title>Economics (ASC) 14-15.xhtml</title>
+        <title>Economics (ASC) 15-16.xhtml</title>
         <link href="template.css" rel="stylesheet" type="text/css" />
     </head>
     <body>
-        <div id="economics-asc-14-15">
+        <div id="economics-asc-15-16">
             <div class="generated-style">
                 <p class="major-name">Economics (ASC)</p>
             </div>
@@ -23,28 +23,84 @@
 <p class="faculty-list"><span class="faculty-list-bold">Professors:</span> Allgood, Anderson, Cushing, Edwards, Fuess, Hayden, May, Rosenbaum, Schmidt, van den Berg, Walstad</p>
 <p class="faculty-list"><span class="faculty-list-bold">Associate Professors:</span> Giertz, McGarvey, Thompson</p>
 <p class="faculty-list"><span class="faculty-list-bold">Assistant Professors:</span> Kim</p>
-<p class="faculty-list"><span class="faculty-list-bold">Assistant Professor of Practice:</span> Miller</p>
-<p class="basic-text">Economic analysis is useful in many decisions made by individuals, businesses, nonprofit organizations, and governments. In addition to opportunities in teaching, economists are employed in many branches of government and on the staffs of corporations in manufacturing, insurance, banking, brokerage and other financial services. Economists often serve as consultants, either individually or in consulting firms. Todays economists deal with problems ranging from monetary and fiscal policy, monopoly and competition, environmental improvement, labor relations, regional development, urban reconstruction, economic development and international business and finance. Economics is also a popular major for students planning to enter professional and graduate programs, particularly in law, foreign service, labor relations, or business administration.</p>
-<p class="basic-text">The department of economics offers the opportunity for intensive study in twelve specialized economic areas:</p>
-<p class="header-paragraph"><span class="header-paragraph-title">General Economics and Theory.</span> Develops fundamental reasoning skills and analytical tools necessary to understand and evaluate economic issues such as specialization, trade, efficiency, costs, markets, prices, resource allocation, money, labor, and government and think critically about economic theory and social provisioning.</p>
-<p class="header-paragraph">Comparative International and Regional Development. Examines how human capital, fiscal policy, natural features, and industry clusters influence the comparative advantage, growth, and standard of living in urban and regional economies between and within countries.</p>
-<p class="header-paragraph"><span class="header-paragraph-title">Econometrics.</span></p>
-<p class="header-paragraph"><span class="header-paragraph-title">Economic Education.</span></p>
-<p class="header-paragraph"><span class="header-paragraph-title">Economic History.</span> Examines the transformation in economic life that accompanied the rise of market capitalism in the United States and focus on the impact of this transformation on the environment, society, and individuals. Courses in this area are integrative in nature and allow students the opportunity to examine the complex nature of economic development throughout American history.</p>
-<p class="header-paragraph"><span class="header-paragraph-title">Industrial Organization and Regulation.</span></p>
-<p class="header-paragraph"><span class="header-paragraph-title">Institutional Economics.</span></p>
-<p class="header-paragraph"><span class="header-paragraph-title">International Trade and Finance.</span> Examines the causes and effects of imports, exports, foreign investment, and migration and their implications for exchange rates, the balance of payments, and economic welfare.</p>
-<p class="header-paragraph"><span class="header-paragraph-title">Labor Economics.</span> Focuses on how labor markets function and thus, how wages and employment are determined. The decisions of labor market participants are studied, as are employment practices and public policies related to employment issues.</p>
-<p class="header-paragraph"><span class="header-paragraph-title">Monetary Economics.</span> Studies the role of money and banking system, and of Federal Reserves monetary policy in the determination of output, employment, interest rates, prices and business cycles in the domestic and open-economy context.</p>
-<p class="header-paragraph"><span class="header-paragraph-title">Public Finance.</span> Survey of taxation and public expenditures in theory and practice. Understanding the logic of collective action, the theory of public goods, social welfare, redistribution and intergovernmental fiscal relations.</p>
-<p class="header-paragraph"><span class="header-paragraph-title">Quantitative Economics.</span></p>
-<p class="basic-text">For some careers, study in related areas is advisable. If you're interested in:</p>
-<ul>
-<li>Human Resource Management take additional courses in labor economics and economic history</li>
-<li>Finance courses in money and banking, intermediate microeconomics, and macroeconomics are helpful</li>
-<li>Marketing econometrics courses add to your resume</li>
-<li>Accounting econometrics and public finance courses covering taxes are useful</li>
-</ul>
+<p class="faculty-list"><span class="faculty-list-bold">Assistant Professor of Practice:</span> Miller, Davidson</p>
+
+<p>Economic analysis is useful in many decisions made by individuals, businesses, nonprofit organizations, and governments. In addition to opportunities in teaching, economists are employed in many branches of government and on the staffs of corporations in manufacturing, insurance, banking, brokerage, and financial services. Economists often serve as consultants, either individually or in consulting firms. Todays economists deal with problems ranging from to include monetary and fiscal policy, monopoly and competition, environmental improvement, labor relations, regional development, urban reconstruction, economic development and international business and finance. Economics is also a popular major for students planning to enter professional and graduate programs, particularly in law, foreign service, labor relations, or business administration, or policy analysis. </p>
+
+<p>COURSES REGULARLY OFFERED</p>
+<p>Fall and Spring Semesters: Courses regularly offered in Fall and Spring semesters by the Department of Economics are as follows: </p>
+
+<p>ECON 200 Economic Essentials and Issues (Qualifies as ACE 6, 8)</p>
+
+<p>ECON 211 Principles of Macroeconomics (Qualifies as ACE 6, 8)</p>
+<p>ECON 211H Honors: Principles of Macroeconomics (Qualifies as ACE 6, 8)</p>
+<p>ECON 212 Principles of Microeconomics (Qualifies as ACE 6, 8)</p>
+<p>ECON 212H Honors: Principles of Microeconomics (Qualifies as ACE 6, 8)</p>
+<p>ECON 215 Statistics (Qualifies as ACE 3)</p>
+<p>ECON 215H Honors: Statistics (Qualifies as ACE 3) </p>
+<p>ECON 311 Intermediate Macroeconomics</p>
+<p>ECON 312 Intermediate Microeconomics</p>
+<p>ECON 321 Introduction to International Economics (Qualifies as ACE 9)</p>
+<p>ECON 340 Introduction to Urban-Regional Economics</p>
+<p>ECON 365 Financial Institutions and Markets</p>
+<p>ECON 399 Independent Study</p>
+<p>ECON 399H Honors Independent Study</p>
+<p>ECON 417 Introductory Econometrics</p>
+<p>ECON 421 International Trade</p>
+<p>ECON 422 International Finance</p>
+<p>ECON 423 Economics of Less Developed Countries</p>
+<p>ECON 440 Regional Development</p>
+<p>ECON 445 Gender Economics and Social Provisioning</p>
+<p>ECON 457 19th Century US Economic History</p>
+<p>ECON 458 20th Century US Economic History</p>
+<p>ECON 466/467 Pro-seminar in International Relations I and II</p>
+<p>ECON 471 Public Finance</p>
+<p>ECON 472 Efficiency in Government</p>
+<p>ECON 481 Economics of Labor Market (Qualifies as ACE 10) </p>
+<p>ECON 482 Labor in the National Economy (Qualifies as ACE 10)</p>
+<p>ECON 499 Independent Study</p>
+<p>ECON 499H Honors Thesis</p>
+
+
+
+<p>Summer Semesters: Courses regularly offered in Summer semesters by the Department of Economics are as follows:</p>
+<p>ECON 211 Principles of Macroeconomics (Qualifies as ACE 6, 8)</p>
+<p>ECON 212 Principles of Microeconomics (Qualifies as ACE 6, 8)</p>
+<p>ECON 215 Statistics (Qualifies as ACE 3)</p>
+<p>ECON 311 Intermediate Macroeconomics</p>
+<p>ECON 312 Intermediate Microeconomics</p>
+<p>Other courses will be occasionally offered in Summer semesters.</p>
+
+
+<p>COURSES AVAILABLE FOR TRANSFER CREDIT</p>
+
+<p>The courses listed above are available to be considered for transfer credit if taken at a different institution. Courses which the Department of Economics does not regularly offer as classes but are also available to be considered for transfer credit if taken at a different institution are as follows:</p>
+<p>ECON 210 Introduction to Economics</p>
+<p>ECON 303 An Introduction to Money and Banking</p>
+<p>ECON 322 Introduction to Development Economics</p>
+<p>ECON 323 The Economic Development of Latin America</p>
+<p>ECON 371 Elements of Public Finance</p>
+<p>ECON 375 Women and Work in USA History</p>
+<p>ECON 381 Introduction to Labor Economics</p>
+<p>ECON 388 Comparative Economic Systems</p>
+<p>ECON 389 Current Economic Issues</p>
+<p>ECON 403 Money and the Financial System</p>
+<p>ECON 404 Current Issues in Monetary Economics</p>
+<p>ECON 409 Applied Public Policy Analysis</p>
+<p>ECON 416 Social Insurance</p>
+<p>ECON 416 Statistics for Decision Making</p>
+<p>ECON 419 Topics in Applied Research</p>
+<p>ECON 426 Government Intervention in Markets</p>
+<p>ECON 433 History of Economic Thought</p>
+<p>ECON 435 Market Competition</p>
+<p>ECON 442 Regional Analysis</p>
+<p>ECON 450 Economics for Teachers</p>
+<p>ECON 451 Economics Issues for Teachers</p>
+<p>ECON 475 Theory and Analysis of Institutional Economics</p>
+<p>ECON 485 The Regulatory Environment for Employment and Labor </p>
+<p>ECON 487 Economies in Transition </p>
+<p><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span></p>
+<ul></ul>
 <p class="header-paragraph">In planning a program of studies, students should consult a faculty adviser or talk to any member of the economics faculty who would be glad to make suggestions about complementary courses.</p>
 <p class="basic-text">Many economics courses also satisfy ACE requirements, (see Other.)</p>
 <p class="content-box-h-1">MAJOR REQUIREMENTS</p>
@@ -60,70 +116,7 @@
 <p class="requirement-sec-1">Total 30</p>
 <p class="asterisk">*<span class="basic-text-bold">NOTE</span> for economics majors: STAT 218 may be substituted for ECON 215 if STAT 218 was completed before declaring economics as a major; otherwise student must take ECON 215.</p>
 <p class="title-1">Track/Options/Concentrations/Emphases Requirements</p>
-<p class="basic-text">While not required, students majoring in economics may choose to pursue areas of interest in the following disciplines to fulfill requirements for the major. Course options appear under each area.</p>
-<p class="title-3">General Economics and Theory</p>
-<p class="list">ECON 389 Current Economic Issues</p>
-<p class="list">ECON 413/FINA 413 Social Insurance</p>
-<p class="list">ECON 433 History of Economic Thought</p>
-<p class="list">ECON 445 Gender, Economics, &amp; Social Provisioning</p>
-<p class="title-3">Comparative International and Regional Development</p>
-<p class="list">ECON 322 Introduction to Development Economics</p>
-<p class="list">ECON 323 The Economic Development of Latin America</p>
-<p class="list">ECON 340 Introduction to Urban-Regional Economics</p>
-<p class="list">ECON 388 Comparative Economic Systems</p>
-<p class="list">ECON 423 Economics of the Less Developed Countries</p>
-<p class="list">ECON 440 Regional Development</p>
-<p class="list">ECON 442 Regional Analysis</p>
-<p class="list">ECON 466 Pro-seminar in International Relations I</p>
-<p class="list">ECON 467 Pro-seminar in International Relations II</p>
-<p class="list">ECON 487 Economies in Transition</p>
-<p class="title-3">Econometrics</p>
-<p class="list">ECON 417 Introductory Econometrics</p>
-<p class="title-3">Economic Education</p>
-<p class="list">(Also see courses in Quantitative Economics)</p>
-<p class="list">ECON 450 Economics for Teachers</p>
-<p class="list">ECON 451 Economics Issues for Teachers</p>
-<p class="title-3">Economic History</p>
-<p class="list">ECON 375 Women &amp; Work in United States History</p>
-<p class="list">ECON 457 19th Century United States Economic History</p>
-<p class="list">ECON 458 20th Century United States Economic History</p>
-<p class="title-3">Industrial Organization and Regulation</p>
-<p class="list">ECON 426 Government Intervention in Markets</p>
-<p class="list">ECON 435 Market Competition</p>
-<p class="list">Also see the following economics courses:</p>
-<p class="list">ECON 457/857 19th Century U.S. Economic History</p>
-<p class="list">ECON 458/858 20th Century U.S. Economic History</p>
-<p class="list">ECON 472/872 Efficiency in Government</p>
-<p class="list">ECON 487/887 Economies in Transition</p>
-<p class="list">ECON 900 Seminar in Economic Theory &amp; Policy</p>
-<p class="title-3">Institutional Economics</p>
-<p class="list">ECON 475 Theory &amp; Analysis of Institutional Economics</p>
-<p class="title-3">International Trade and Finance</p>
-<p class="list">ECON 321 Introduction to International Economics</p>
-<p class="list">ECON 421 International Trade</p>
-<p class="list">ECON 422 International Finance</p>
-<p class="list">For additional courses, see Comparative International &amp; Regional Development</p>
-<p class="title-3">Labor Economics</p>
-<p class="list">ECON 381 Introduction to Labor Economics</p>
-<p class="list">ECON 481 Economics of the Labor Market <em>(ACE 10 approved)</em></p>
-
-<p class="list">ECON 482 Labor in the National Economy <em>(ACE 10 approved)</em></p>
-
-<p class="list">ECON 485 The Regulatory Environment for Employment &amp; Labor</p>
-<p class="title-3">Monetary Economics</p>
-<p class="list">ECON 303 An Introduction to Money &amp; Banking</p>
-<p class="list">ECON 365 Financial Institutions &amp; Markets</p>
-<p class="list">ECON 403 Money &amp; the Financial System</p>
-<p class="list">ECON 404 Current Issues in Monetary Economics</p>
-<p class="title-3">Public Finance</p>
-<p class="list">ECON 371 Elements of Public Finance</p>
-<p class="list">ECON 471 Public Finance</p>
-<p class="list">ECON 472 Efficiency in Government</p>
-<p class="title-3">Quantitative Economics</p>
-<p class="list">ECON 409 Applied Public Policy Analysis</p>
-<p class="list">ECON 416 Statistics for Decision Making</p>
-<p class="list">ECON 419 Topics in Applied Research</p>
-<p class="list">Also see Econometrics area for additional courses in quantitative economics.</p>
+<p class="basic-text"><em></em><em></em></p>
 <p class="title-3">Research and Thesis</p>
 <p class="list">Seminar and research courses in specific fields are listed in their respective divisions.</p>
 <p class="list">ECON 189H University Honors Seminar</p>
@@ -131,7 +124,8 @@
 <p class="list">ECON 399 Independent Study</p>
 <p class="list">ECON 399H Honors: Independent Study</p>
 <p class="list">ECON 499H Honors Thesis</p>
-<p class="basic-text">This department participates in the program for Global Studies. For a full description of the program, see Global Studies.</p>
+
+<p>This department participates in the program for Global Studies and UCARE. For a full description of these programs, see Global Studies and UCARE. </p>
 <p class="header-paragraph"><span class="header-paragraph-title">Graduate Work.</span> The advanced degrees of master of arts and doctor of philosophy are offered. For details of these programs see the Graduate Studies Bulletin. Refer to the Graduate Studies Bulletin for 800/900-level courses.</p>
 <p class="content-box-h-1">ADDITIONAL MAJOR REQUIREMENTS</p>
 <p class="basic-text">Students are required to complete ECON 211, ECON 212, and ECON 215 before completing additional required economics course work. The completion of BSAD 150 and MATH 104 are required prior to enrollment in ECON 215. We strongly recommend students complete the intermediate theory sequence, ECON 311 and ECON 312, prior to completing elective 300 and 400 level classes.</p>

--- a/data/2015/majors/Economics (ASC).xhtml
+++ b/data/2015/majors/Economics (ASC).xhtml
@@ -22,69 +22,61 @@
 <p class="faculty-list"><span class="faculty-list-bold">Chair: Scott M. Fuess, Jr.,</span> 340 College of Business Administration Building</p>
 <p class="faculty-list"><span class="faculty-list-bold">Professors:</span> Allgood, Anderson, Cushing, Edwards, Fuess, Hayden, May, Rosenbaum, Schmidt, van den Berg, Walstad</p>
 <p class="faculty-list"><span class="faculty-list-bold">Associate Professors:</span> Giertz, McGarvey, Thompson</p>
-<p class="faculty-list"><span class="faculty-list-bold">Assistant Professors:</span> Kim</p>
-<p class="faculty-list"><span class="faculty-list-bold">Assistant Professor of Practice:</span> Miller, Davidson</p>
+<p class="faculty-list"><span class="faculty-list-bold">Assistant Professor:</span> Kim</p>
+<p class="faculty-list"><span class="faculty-list-bold">Assistant Professors of Practice:</span> Miller, Davidson</p>
 
 <p>Economic analysis is useful in many decisions made by individuals, businesses, nonprofit organizations, and governments. In addition to opportunities in teaching, economists are employed in many branches of government and on the staffs of corporations in manufacturing, insurance, banking, brokerage, and financial services. Economists often serve as consultants, either individually or in consulting firms. Todays economists deal with problems ranging from to include monetary and fiscal policy, monopoly and competition, environmental improvement, labor relations, regional development, urban reconstruction, economic development and international business and finance. Economics is also a popular major for students planning to enter professional and graduate programs, particularly in law, foreign service, labor relations, or business administration, or policy analysis. </p>
 
-<p>COURSES REGULARLY OFFERED</p>
-<p>Fall and Spring Semesters: Courses regularly offered in Fall and Spring semesters by the Department of Economics are as follows: </p>
-
-<p>ECON 200 Economic Essentials and Issues (Qualifies as ACE 6, 8)</p>
-
-<p>ECON 211 Principles of Macroeconomics (Qualifies as ACE 6, 8)</p>
-<p>ECON 211H Honors: Principles of Macroeconomics (Qualifies as ACE 6, 8)</p>
-<p>ECON 212 Principles of Microeconomics (Qualifies as ACE 6, 8)</p>
-<p>ECON 212H Honors: Principles of Microeconomics (Qualifies as ACE 6, 8)</p>
-<p>ECON 215 Statistics (Qualifies as ACE 3)</p>
-<p>ECON 215H Honors: Statistics (Qualifies as ACE 3) </p>
-<p>ECON 311 Intermediate Macroeconomics</p>
-<p>ECON 312 Intermediate Microeconomics</p>
-<p>ECON 321 Introduction to International Economics (Qualifies as ACE 9)</p>
-<p>ECON 340 Introduction to Urban-Regional Economics</p>
-<p>ECON 365 Financial Institutions and Markets</p>
-<p>ECON 399 Independent Study</p>
-<p>ECON 399H Honors Independent Study</p>
-<p>ECON 417 Introductory Econometrics</p>
-<p>ECON 421 International Trade</p>
-<p>ECON 422 International Finance</p>
-<p>ECON 423 Economics of Less Developed Countries</p>
-<p>ECON 440 Regional Development</p>
-<p>ECON 445 Gender Economics and Social Provisioning</p>
-<p>ECON 457 19th Century US Economic History</p>
-<p>ECON 458 20th Century US Economic History</p>
-<p>ECON 466/467 Pro-seminar in International Relations I and II</p>
-<p>ECON 471 Public Finance</p>
-<p>ECON 472 Efficiency in Government</p>
-<p>ECON 481 Economics of Labor Market (Qualifies as ACE 10) </p>
-<p>ECON 482 Labor in the National Economy (Qualifies as ACE 10)</p>
-<p>ECON 499 Independent Study</p>
-<p>ECON 499H Honors Thesis</p>
-
-
-
-<p>Summer Semesters: Courses regularly offered in Summer semesters by the Department of Economics are as follows:</p>
-<p>ECON 211 Principles of Macroeconomics (Qualifies as ACE 6, 8)</p>
-<p>ECON 212 Principles of Microeconomics (Qualifies as ACE 6, 8)</p>
-<p>ECON 215 Statistics (Qualifies as ACE 3)</p>
-<p>ECON 311 Intermediate Macroeconomics</p>
-<p>ECON 312 Intermediate Microeconomics</p>
+<p class="title-2">Courses Regularly Offered</p>
+<p class="header-paragraph"><span class="header-paragraph-title">Fall and Spring Semesters:</span> Courses regularly offered in Fall and Spring semesters by the Department of Economics are as follows: </p>
+<p class="requirement-sec-2">ECON 200 Economic Essentials &amp; Issues <span class="requirement-ital">(Qualifies as ACE 6, 8)</span></p>
+<p class="requirement-sec-2">ECON 211 Principles of Macroeconomics <span class="requirement-ital">(Qualifies as ACE 6, 8)</span></p>
+<p class="requirement-sec-2">ECON 211H Honors: Principles of Macroeconomics <span class="requirement-ital">(Qualifies as ACE 6, 8)</span></p>
+<p class="requirement-sec-2">ECON 212 Principles of Microeconomics <span class="requirement-ital">(Qualifies as ACE 6, 8)</span></p>
+<p class="requirement-sec-2">ECON 212H Honors: Principles of Microeconomics <span class="requirement-ital">(Qualifies as ACE 6, 8)</span></p>
+<p class="requirement-sec-2">ECON 215 Statistics <span class="requirement-ital">(Qualifies as ACE 3)</span></p>
+<p class="requirement-sec-2">ECON 215H Honors: Statistics <span class="requirement-ital">(Qualifies as ACE 3) </span></p>
+<p class="requirement-sec-2">ECON 311 Intermediate Macroeconomics</p>
+<p class="requirement-sec-2">ECON 312 Intermediate Microeconomics</p>
+<p class="requirement-sec-2">ECON 321 Introduction to International Economics <span class="requirement-ital">(Qualifies as ACE 9)</span></p>
+<p class="requirement-sec-2">ECON 340 Introduction to Urban-Regional Economics</p>
+<p class="requirement-sec-2">ECON 365 Financial Institutions &amp; Markets</p>
+<p class="requirement-sec-2">ECON 399 Independent Study</p>
+<p class="requirement-sec-2">ECON 399H Honors Independent Study</p>
+<p class="requirement-sec-2">ECON 417 Introductory Econometrics</p>
+<p class="requirement-sec-2">ECON 421 International Trade</p>
+<p class="requirement-sec-2">ECON 422 International Finance</p>
+<p class="requirement-sec-2">ECON 423 Economics of Less Developed Countries</p>
+<p class="requirement-sec-2">ECON 440 Regional Development</p>
+<p class="requirement-sec-2">ECON 445 Gender Economics &amp; Social Provisioning</p>
+<p class="requirement-sec-2">ECON 457 19th Century U.S. Economic History</p>
+<p class="requirement-sec-2">ECON 458 20th Century U.S. Economic History</p>
+<p class="requirement-sec-2">ECON 466 &amp; ECON 467 Pro-seminar in International Relations I &amp; II</p>
+<p class="requirement-sec-2">ECON 471 Public Finance</p>
+<p class="requirement-sec-2">ECON 472 Efficiency in Government</p>
+<p class="requirement-sec-2">ECON 481 Economics of Labor Market <span class="requirement-ital">(Qualifies as ACE 10) </span></p>
+<p class="requirement-sec-2">ECON 482 Labor in the National Economy <span class="requirement-ital">(Qualifies as ACE 10)</span></p>
+<p class="requirement-sec-2">ECON 499 Independent Study</p>
+<p class="requirement-sec-2">ECON 499H Honors Thesis</p>
+<p class="header-paragraph"><span class="header-paragraph-title">Summer Semesters:</span> Courses regularly offered in Summer semesters by the Department of Economics are as follows:</p>
+<p class="requirement-sec-2">ECON 211 Principles of Macroeconomics <span class="requirement-ital">(Qualifies as ACE 6, 8)</span></p>
+<p class="requirement-sec-2">ECON 212 Principles of Microeconomics <span class="requirement-ital">(Qualifies as ACE 6, 8)</span></p>
+<p class="requirement-sec-2">ECON 215 Statistics <span class="requirement-ital">(Qualifies as ACE 3)</span></p>
+<p class="requirement-sec-2">ECON 311 Intermediate Macroeconomics</p>
+<p class="requirement-sec-2">ECON 312 Intermediate Microeconomics</p>
 <p>Other courses will be occasionally offered in Summer semesters.</p>
-
-
-<p>COURSES AVAILABLE FOR TRANSFER CREDIT</p>
-
+<p>Courses Available for Transfer Credit</p>
 <p>The courses listed above are available to be considered for transfer credit if taken at a different institution. Courses which the Department of Economics does not regularly offer as classes but are also available to be considered for transfer credit if taken at a different institution are as follows:</p>
 <p>ECON 210 Introduction to Economics</p>
-<p>ECON 303 An Introduction to Money and Banking</p>
+<p>ECON 303 An Introduction to Money &amp; Banking</p>
 <p>ECON 322 Introduction to Development Economics</p>
 <p>ECON 323 The Economic Development of Latin America</p>
 <p>ECON 371 Elements of Public Finance</p>
-<p>ECON 375 Women and Work in USA History</p>
+<p>ECON 375 Women &amp; Work in U.S.A. History</p>
 <p>ECON 381 Introduction to Labor Economics</p>
 <p>ECON 388 Comparative Economic Systems</p>
 <p>ECON 389 Current Economic Issues</p>
-<p>ECON 403 Money and the Financial System</p>
+<p>ECON 403 Money &amp; the Financial System</p>
 <p>ECON 404 Current Issues in Monetary Economics</p>
 <p>ECON 409 Applied Public Policy Analysis</p>
 <p>ECON 416 Social Insurance</p>
@@ -96,8 +88,8 @@
 <p>ECON 442 Regional Analysis</p>
 <p>ECON 450 Economics for Teachers</p>
 <p>ECON 451 Economics Issues for Teachers</p>
-<p>ECON 475 Theory and Analysis of Institutional Economics</p>
-<p>ECON 485 The Regulatory Environment for Employment and Labor </p>
+<p>ECON 475 Theory &amp; Analysis of Institutional Economics</p>
+<p>ECON 485 The Regulatory Environment for Employment &amp; Labor </p>
 <p>ECON 487 Economies in Transition </p>
 <p><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span></p>
 <ul></ul>

--- a/data/2015/majors/Economics (ASC).xhtml
+++ b/data/2015/majors/Economics (ASC).xhtml
@@ -40,21 +40,22 @@
 <p class="requirement-sec-2">ECON 312 Intermediate Microeconomics</p>
 <p class="requirement-sec-2">ECON 321 Introduction to International Economics <span class="requirement-ital">(Qualifies as ACE 9)</span></p>
 <p class="requirement-sec-2">ECON 340 Introduction to Urban-Regional Economics</p>
-<p class="requirement-sec-2">ECON 365 Financial Institutions &amp; Markets</p>
+<p class="requirement-sec-2">ECON 365 Financial Institutions &amp; Markets (FINA 365)</p>
 <p class="requirement-sec-2">ECON 399 Independent Study</p>
-<p class="requirement-sec-2">ECON 399H Honors Independent Study</p>
+<p class="requirement-sec-2">ECON 399H Honors: Independent Study</p>
 <p class="requirement-sec-2">ECON 417 Introductory Econometrics</p>
 <p class="requirement-sec-2">ECON 421 International Trade</p>
 <p class="requirement-sec-2">ECON 422 International Finance</p>
 <p class="requirement-sec-2">ECON 423 Economics of Less Developed Countries</p>
 <p class="requirement-sec-2">ECON 440 Regional Development</p>
-<p class="requirement-sec-2">ECON 445 Gender Economics &amp; Social Provisioning</p>
-<p class="requirement-sec-2">ECON 457 19th Century U.S. Economic History</p>
-<p class="requirement-sec-2">ECON 458 20th Century U.S. Economic History</p>
-<p class="requirement-sec-2">ECON 466 &amp; ECON 467 Pro-seminar in International Relations I &amp; II</p>
+<p class="requirement-sec-2">ECON 445 Gender Economics &amp; Social Provisioning (WMNS 445)</p>
+<p class="requirement-sec-2">ECON 457 19th Century U.S. Economic History (HIST 457)</p>
+<p class="requirement-sec-2">ECON 458 20th Century U.S. Economic History (HIST 458)</p>
+<p class="requirement-sec-2">ECON 466 Pro-seminar in International Relations I (AECN 467, ANTH 479, GEOG 448, HIST 479, POLS 466, SOCI 466)</p>
+<p class="requirement-sec-2">ECON 467 Pro-seminar in International Relations II (POLS 467)</p>
 <p class="requirement-sec-2">ECON 471 Public Finance</p>
 <p class="requirement-sec-2">ECON 472 Efficiency in Government</p>
-<p class="requirement-sec-2">ECON 481 Economics of Labor Market <span class="requirement-ital">(Qualifies as ACE 10) </span></p>
+<p class="requirement-sec-2">ECON 481 Economics of the Labor Market <span class="requirement-ital">(Qualifies as ACE 10) </span></p>
 <p class="requirement-sec-2">ECON 482 Labor in the National Economy <span class="requirement-ital">(Qualifies as ACE 10)</span></p>
 <p class="requirement-sec-2">ECON 499 Independent Study</p>
 <p class="requirement-sec-2">ECON 499H Honors Thesis</p>
@@ -72,14 +73,14 @@
 <p class="requirement-sec-2">ECON 322 Introduction to Development Economics</p>
 <p class="requirement-sec-2">ECON 323 The Economic Development of Latin America</p>
 <p class="requirement-sec-2">ECON 371 Elements of Public Finance</p>
-<p class="requirement-sec-2">ECON 375 Women &amp; Work in U.S.A. History</p>
+<p class="requirement-sec-2">ECON 375 Women &amp; Work in U.S.A. History (HIST 375/WMNS 375)</p>
 <p class="requirement-sec-2">ECON 381 Introduction to Labor Economics</p>
 <p class="requirement-sec-2">ECON 388 Comparative Economic Systems</p>
 <p class="requirement-sec-2">ECON 389 Current Economic Issues</p>
 <p class="requirement-sec-2">ECON 403 Money &amp; the Financial System</p>
 <p class="requirement-sec-2">ECON 404 Current Issues in Monetary Economics</p>
 <p class="requirement-sec-2">ECON 409 Applied Public Policy Analysis</p>
-<p class="requirement-sec-2">ECON 416 Social Insurance</p>
+<p class="requirement-sec-2">ECON 413 Social Insurance (FINA 413)</p>
 <p class="requirement-sec-2">ECON 416 Statistics for Decision Making</p>
 <p class="requirement-sec-2">ECON 419 Topics in Applied Research</p>
 <p class="requirement-sec-2">ECON 426 Government Intervention in Markets</p>
@@ -89,7 +90,7 @@
 <p class="requirement-sec-2">ECON 450 Economics for Teachers</p>
 <p class="requirement-sec-2">ECON 451 Economics Issues for Teachers</p>
 <p class="requirement-sec-2">ECON 475 Theory &amp; Analysis of Institutional Economics</p>
-<p class="requirement-sec-2">ECON 485 The Regulatory Environment for Employment &amp; Labor </p>
+<p class="requirement-sec-2">ECON 485 The Regulatory Environment for Employment &amp; Labor (MNGT 466)</p>
 <p class="requirement-sec-2">ECON 487 Economies in Transition </p>
 <p><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span></p>
 <ul></ul>

--- a/data/2015/majors/Economics (ASC).xhtml
+++ b/data/2015/majors/Economics (ASC).xhtml
@@ -111,11 +111,11 @@
 <p class="basic-text"><em></em><em></em></p>
 <p class="title-3">Research and Thesis</p>
 <p class="list">Seminar and research courses in specific fields are listed in their respective divisions.</p>
-<p class="list">ECON 189H University Honors Seminar</p>
-<p class="list">ECON 198 Freshman Seminar</p>
-<p class="list">ECON 399 Independent Study</p>
-<p class="list">ECON 399H Honors: Independent Study</p>
-<p class="list">ECON 499H Honors Thesis</p>
+<p class="requirement-sec-2">ECON 189H University Honors Seminar</p>
+<p class="requirement-sec-2">ECON 198 Freshman Seminar</p>
+<p class="requirement-sec-2">ECON 399 Independent Study</p>
+<p class="requirement-sec-2">ECON 399H Honors: Independent Study</p>
+<p class="requirement-sec-2">ECON 499H Honors Thesis</p>
 
 <p>This department participates in the program for Global Studies and UCARE. For a full description of these programs, see Global Studies and UCARE. </p>
 <p class="header-paragraph"><span class="header-paragraph-title">Graduate Work.</span> The advanced degrees of master of arts and doctor of philosophy are offered. For details of these programs see the Graduate Studies Bulletin. Refer to the Graduate Studies Bulletin for 800/900-level courses.</p>

--- a/data/2015/majors/Economics (ASC).xhtml
+++ b/data/2015/majors/Economics (ASC).xhtml
@@ -65,32 +65,32 @@
 <p class="requirement-sec-2">ECON 311 Intermediate Macroeconomics</p>
 <p class="requirement-sec-2">ECON 312 Intermediate Microeconomics</p>
 <p>Other courses will be occasionally offered in Summer semesters.</p>
-<p>Courses Available for Transfer Credit</p>
-<p>The courses listed above are available to be considered for transfer credit if taken at a different institution. Courses which the Department of Economics does not regularly offer as classes but are also available to be considered for transfer credit if taken at a different institution are as follows:</p>
-<p>ECON 210 Introduction to Economics</p>
-<p>ECON 303 An Introduction to Money &amp; Banking</p>
-<p>ECON 322 Introduction to Development Economics</p>
-<p>ECON 323 The Economic Development of Latin America</p>
-<p>ECON 371 Elements of Public Finance</p>
-<p>ECON 375 Women &amp; Work in U.S.A. History</p>
-<p>ECON 381 Introduction to Labor Economics</p>
-<p>ECON 388 Comparative Economic Systems</p>
-<p>ECON 389 Current Economic Issues</p>
-<p>ECON 403 Money &amp; the Financial System</p>
-<p>ECON 404 Current Issues in Monetary Economics</p>
-<p>ECON 409 Applied Public Policy Analysis</p>
-<p>ECON 416 Social Insurance</p>
-<p>ECON 416 Statistics for Decision Making</p>
-<p>ECON 419 Topics in Applied Research</p>
-<p>ECON 426 Government Intervention in Markets</p>
-<p>ECON 433 History of Economic Thought</p>
-<p>ECON 435 Market Competition</p>
-<p>ECON 442 Regional Analysis</p>
-<p>ECON 450 Economics for Teachers</p>
-<p>ECON 451 Economics Issues for Teachers</p>
-<p>ECON 475 Theory &amp; Analysis of Institutional Economics</p>
-<p>ECON 485 The Regulatory Environment for Employment &amp; Labor </p>
-<p>ECON 487 Economies in Transition </p>
+<p class="title-2">Courses Available for Transfer Credit</p>
+<p class="header-paragraph">The courses listed above are available to be considered for transfer credit if taken at a different institution. Courses which the Department of Economics does not regularly offer as classes but are also available to be considered for transfer credit if taken at a different institution are as follows:</p>
+<p class="requirement-sec-2">ECON 210 Introduction to Economics</p>
+<p class="requirement-sec-2">ECON 303 An Introduction to Money &amp; Banking</p>
+<p class="requirement-sec-2">ECON 322 Introduction to Development Economics</p>
+<p class="requirement-sec-2">ECON 323 The Economic Development of Latin America</p>
+<p class="requirement-sec-2">ECON 371 Elements of Public Finance</p>
+<p class="requirement-sec-2">ECON 375 Women &amp; Work in U.S.A. History</p>
+<p class="requirement-sec-2">ECON 381 Introduction to Labor Economics</p>
+<p class="requirement-sec-2">ECON 388 Comparative Economic Systems</p>
+<p class="requirement-sec-2">ECON 389 Current Economic Issues</p>
+<p class="requirement-sec-2">ECON 403 Money &amp; the Financial System</p>
+<p class="requirement-sec-2">ECON 404 Current Issues in Monetary Economics</p>
+<p class="requirement-sec-2">ECON 409 Applied Public Policy Analysis</p>
+<p class="requirement-sec-2">ECON 416 Social Insurance</p>
+<p class="requirement-sec-2">ECON 416 Statistics for Decision Making</p>
+<p class="requirement-sec-2">ECON 419 Topics in Applied Research</p>
+<p class="requirement-sec-2">ECON 426 Government Intervention in Markets</p>
+<p class="requirement-sec-2">ECON 433 History of Economic Thought</p>
+<p class="requirement-sec-2">ECON 435 Market Competition</p>
+<p class="requirement-sec-2">ECON 442 Regional Analysis</p>
+<p class="requirement-sec-2">ECON 450 Economics for Teachers</p>
+<p class="requirement-sec-2">ECON 451 Economics Issues for Teachers</p>
+<p class="requirement-sec-2">ECON 475 Theory &amp; Analysis of Institutional Economics</p>
+<p class="requirement-sec-2">ECON 485 The Regulatory Environment for Employment &amp; Labor </p>
+<p class="requirement-sec-2">ECON 487 Economies in Transition </p>
 <p><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span><span class="header-paragraph-title"></span></p>
 <ul></ul>
 <p class="header-paragraph">In planning a program of studies, students should consult a faculty adviser or talk to any member of the economics faculty who would be glad to make suggestions about complementary courses.</p>
@@ -127,8 +127,14 @@
 <p class="title-2">Course Level Requirement</p>
 <p class="basic-text">Completion of ECON 311 and ECON 312 is recommended before taking other 300/400-level economics courses.</p>
 <p class="content-box-h-1">REQUIREMENTS FOR MINOR OFFERED BY DEPARTMENT</p>
-<p class="header-paragraph"><span class="header-paragraph-title">Plan A:</span> 18 hours of economics course work</p>
-<p class="header-paragraph"><span class="header-paragraph-title">Plan B:</span> 12 hours of economics course work</p>
+<p class="title-3">Plan A</p>
+<ul>
+<li>18 hours of economics course work</li>
+</ul>
+<p class="title-3">Plan B</p>
+<ul>
+<li>12 hours of economics course work</li>
+</ul>
 <p class="content-box-h-1">OTHER</p>
 <p class="basic-text">All students are required to meet the prerequisites listed for each course, including any specific grade or GPA requirement, to include all requirements for enrollment in 300- or 400-level economics courses.</p>
 <p class="basic-text">ECON 211 and ECON 212 Macro- and Microeconomics are ACE 6 and ACE 8 approved course work.</p>


### PR DESCRIPTION
Per Dr. Gregory Hayden: 

The Department of Economics has not made any substantive changes in the ASC bulletin. That is, there are no changes with regard to course descriptions, hours required, recommended order of studies, etc. 

The changes that have been made are made to delete the cluttered material in the old bulletin and to make the bulletin a convenient tool for students. The new bulletin makes it easier for students to plan their course registration by presenting  the students an easy to read single list of the courses that the students can depend on being offered on a regular basis. The course list of regularly offered courses also includes the ACE designation for each course to make it easier for students and advisors across campus to plan course schedules. Given the growing number of students seeking transfer credit for various courses taken at other institutions, the new bulletin also provides a list of courses that are not regularly offered as classes but are available to be used for transfer credit, along with the list of courses that are  regularly offered. This will make it easier for advisors in the ASC to advise students about the courses to which the courses taken at other institutions might transfer. 

The material deleted from the old bulletin was cluttered, misdirectional, and incomplete. The old material gave a list of areas and tracks, most of which do not exist. In the first list of areas in the old bulletin, some areas were listed without any description, others that were listed are not available for undergradate students, and for other listed areas and there are no courses offered. Likewise, when tracks/options were listed, courses were listed that are never offered and options were listed that are never offered.  

The new bulletin can be read easily and serve as a planning tool for students and advisors alike. And, more importantly, it is honest and reliable. 
