### PR TITLE
Finalize Request #7517

### DIFF
--- a/data/2015/majors/German (ASC).xhtml
+++ b/data/2015/majors/German (ASC).xhtml
@@ -48,28 +48,29 @@
 
 <p class="requirement-sec-1">27 hours (of courses numbered 300 or above)</p>
 <p class="requirement-sec-2">– Core: GERM 301, GERM 302, GERM 303, GERM 304, GERM 403</p>
-<p class="requirement-sec-2">– 3 additional hours of elective GERM courses at 300 level or above (these may include German classes offered in English)</p>
+<p class="requirement-sec-2">– 3 additional hours of elective GERM courses at 300 level or above <span class="requirement-ital">(these may include German classes offered in English)</span></p>
 <p class="requirement-sec-2">– 6 additional hours of elective GERM courses at 400 level</p>
 <p class="requirement-sec-2">– 3 additional elective credit hours. These 3 hours may be from:</p>
 
 <p class="requirement-sec-3"> - a 300 or 400 level GERM class</p>
 <p class="requirement-sec-3"> - a 300 or 400 level MODL class as approved by the undergraduate advisor</p>
-<p class="requirement-sec-3"> - from a class with a German studies focus in English, History, Music, Political Science, Philosophy, Art History, Theater as approved by the undergraduate advisor. Specific classes that may be used to fulfill this requirement are:</p>
+<p class="requirement-sec-3"> - from a class with a German studies focus in English, history, music, political science, philosophy, art history, or theater as approved by the undergraduate advisor. Specific classes that may be used to fulfill this requirement are:</p>
 <p class="requirement-sec-4">AHIS 226 Northern Renaissance Art</p>
 <p class="requirement-sec-4">AHIS 426 Northern Renaissance &amp; Reformation Art</p>
-<p class="requirement-sec-4">AHIS 498 Special Problems: German Film &amp; Art between the Wars</p>
+<p class="requirement-sec-4">AHIS 498 Special Problems: German Art &amp; Film  between  Wars</p>
 <p class="requirement-sec-4">HIST 327 19th Century Germany</p>
-<p class="requirement-sec-4">HIST 328 History of Germany, 1914-present</p>
-<p class="requirement-sec-4">HIST 339 The Holocaust</p>
-<p class="requirement-sec-4">HIST 421 The German Reformation (Cross-listed with German)</p>
+<p class="requirement-sec-4">HIST 328 History of Germany, 1914 to Present</p>
+<p class="requirement-sec-4">HIST 339 The Holocaust (JUDS 339)</p>
+<p class="requirement-sec-4">HIST 421 The German Reformation (MRST 421/RELG 421) (Cross-listed with German)</p>
 <p class="requirement-sec-4">HIST 429 History of Fascism in Europe</p>
-<p class="requirement-sec-4">MUSC 442 Great Composers</p>
-<p class="requirement-sec-4">PHIL 333 History of Philosophy</p>
-<p class="requirement-sec-4">PHIL 345 Modern European Jewish Philosophy</p>
+<p class="requirement-sec-4">MUSC 442 Great Composers &amp; Performers in Music</p>
+<p class="requirement-sec-4">PHIL 333 History of Philosophy (19th Century)</p>
+<p class="requirement-sec-4">PHIL 345 Modern European Jewish Philosophy (JUDS 345)</p>
 <p class="requirement-sec-4">PHIL 471 Kant</p>
-<p class="requirement-sec-4">POLS 371 The Politics of the European Union</p>
 <p class="requirement-sec-4">(Classes in Film Studies offered through the Department of English are possible in consultation with instructor and German Section.)</p>
-<p class="header-paragraph-title">Program Assessment. <span class="header-paragraph">In order to assist the department in evaluating the effectiveness of its programs, majors will be required to assemble and maintain a portfolio. In their junior year, majors will be assigned a faculty adviser who will inform students of the required contents of the portfolio, deadlines and procedures. By their senior year, majors will be required to complete a taped oral proficiency interview.</span></p>
+<p>Minor Requirements</p>
+<p>A minor is required and may be taken in any area.</p>
+<p class="header-paragraph"><span class="header-paragraph-title">Program Assessment.</span> In order to assist the department in evaluating the effectiveness of its programs, majors will be required to assemble and maintain a portfolio. In their junior year, majors will be assigned a faculty adviser who will inform students of the required contents of the portfolio, deadlines and procedures. By their senior year, majors will be required to complete a taped oral proficiency interview.</p>
 <p class="basic-text">Results of participation in this assessment activity will in no way affect a student’s GPA or graduation.</p>
 
 <p><span class="header-paragraph-title"></span></p>

--- a/data/2015/majors/German (ASC).xhtml
+++ b/data/2015/majors/German (ASC).xhtml
@@ -70,12 +70,13 @@
 <p style="margin: 0px; font-size: 11px; font-family: Helvetica;">PHIL 345 Modern European Jewish Philosophy</p>
 <p style="margin: 0px; font-size: 11px; font-family: Helvetica;">PHIL 471 Kant</p>
 <p style="margin: 0px; font-size: 11px; font-family: Helvetica;">POLS 371 The Politics of the European Union</p>
-<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">(Classes in Film Studies offered through the Department of English are possible</p>
+<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">(Classes in Film Studies offered through the Department of English are possible in consultation with instructor and German Section.)</p>
 
-<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">in consultation with instructor and German Section</p>
-<ul>
-<li><span class="header-paragraph-title"></span></li>
-</ul>
+
+<p><strong>Program Assessment.</strong> In order to assist the department in evaluating the effectiveness of its programs, majors will be required to assemble and maintain a portfolio. In their junior year, majors will be assigned a faculty adviser who will inform students of the required contents of the portfolio, deadlines and procedures. By their senior year, majors will be required to complete a taped oral proficiency interview.</p>
+<p>Results of participation in this assessment activity will in no way affect a student’s GPA or graduation.</p>
+
+<p><span class="header-paragraph-title"></span></p>
 <p class="content-box-h-1">ADDITIONAL MAJOR REQUIREMENTS</p>
 <p class="title-1">Grade Rules</p>
 <p class="title-2">Pass/No Pass Limits</p>

--- a/data/2015/majors/German (ASC).xhtml
+++ b/data/2015/majors/German (ASC).xhtml
@@ -47,27 +47,29 @@
 <p class="title-1">Specific Major Requirements:</p>
 
 <p class="requirement-sec-1">27 hours (of courses numbered 300 or above)</p>
+<p class="requirement-sec-2">Core: GERM 301, GERM 302, GERM 303, GERM 304, GERM 403</p>
+<p class="requirement-sec-2">3 additional hours of elective GERM courses at 300 level or above (these may include German classes offered in English)</p>
+<p class="requirement-sec-2">6 additional hours of elective GERM courses at 400 level</p>
+<p class="requirement-sec-2">3 additional elective credit hours. These 3 hours may be from:</p>
 
-<p><span class="requirement-sec-2">Core: GERM 301, GERM 302, GERM 303, GERM 304, GERM 403</span><br /><span class="requirement-sec-2">3 additional hours of elective GERM courses at 300 level or above (these may include</span> German<span class="requirement-sec-2"> classes offered in English)</span><br /><span class="requirement-sec-2" style="font-family: Helvetica; font-size: 11px;">6 additional hours of elective GERM courses at 400 level</span><br /><span class="requirement-sec-2" style="font-family: Helvetica; font-size: 11px;">3 additional elective credit hours. These 3 hours may be from:</span></p>
-
-<p class="requirement-sec-3" style="margin: 0px; font-size: 11px; font-family: Helvetica;"> a 300 or 400 level GERM class,</p>
-<p class="requirement-sec-3" style="margin: 0px; font-size: 11px; font-family: Helvetica;"> a 300 or 400 level MODL class as approved by the undergraduate advisor.</p>
-<p class="requirement-sec-3" style="margin: 0px; font-size: 11px; font-family: Helvetica;"> from a class with a German studies focus in English, History, Music, Political Science, Philosophy, Art History, Theater as approved by the undergraduate advisor. Specific classes that me be used to fulfill this requirement are:</p>
-<p class="requirement-sec-4" style="margin: 0px; font-size: 11px; font-family: Helvetica;">AHIS 226 Northern Renaissance Art</p>
-<p class="requirement-sec-4" style="margin: 0px; font-size: 11px; font-family: Helvetica;">AHIS 426 Northern Renaissance &amp; Reformation Art</p>
-<p class="requirement-sec-4" style="margin: 0px; font-size: 11px; font-family: Helvetica;">AHIS 498 Special Problems: German Film &amp; Art between the Wars</p>
-<p class="requirement-sec-4" style="margin: 0px; font-size: 11px; font-family: Helvetica;">HIST 327 19th Century Germany</p>
-<p class="requirement-sec-4" style="margin: 0px; font-size: 11px; font-family: Helvetica;">HIST 328 History of Germany, 1914-present</p>
-<p class="requirement-sec-4" style="margin: 0px; font-size: 11px; font-family: Helvetica;">HIST 339 The Holocaust</p>
-<p class="requirement-sec-4" style="margin: 0px; font-size: 11px; font-family: Helvetica;">HIST 421 The German Reformation (Cross-listed with German)</p>
-<p class="requirement-sec-4" style="margin: 0px; font-size: 11px; font-family: Helvetica;">HIST 429 History of Fascism in Europe</p>
-<p class="requirement-sec-4" style="margin: 0px; font-size: 11px; font-family: Helvetica;">MUSC 442 Great Composers</p>
-<p class="requirement-sec-4" style="margin: 0px; font-size: 11px; font-family: Helvetica;">PHIL 333 History of Philosophy</p>
-<p class="requirement-sec-4" style="margin: 0px; font-size: 11px; font-family: Helvetica;">PHIL 345 Modern European Jewish Philosophy</p>
-<p class="requirement-sec-4" style="margin: 0px; font-size: 11px; font-family: Helvetica;">PHIL 471 Kant</p>
-<p class="requirement-sec-4" style="margin: 0px; font-size: 11px; font-family: Helvetica;">POLS 371 The Politics of the European Union</p>
-<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">(Classes in Film Studies offered through the Department of English are possible in consultation with instructor and German Section.)</p>
-<p style="margin: 0px; font-size: 11px; font-family: Helvetica;"><span class="header-paragraph-title">Program Assessment.</span> <span class="header-paragraph">In order to assist the department in evaluating the effectiveness of its programs, majors will be required to assemble and maintain a portfolio. In their junior year, majors will be assigned a faculty adviser who will inform students of the required contents of the portfolio, deadlines and procedures. By their senior year, majors will be required to complete a taped oral proficiency interview.</span></p>
+<p class="requirement-sec-3"> a 300 or 400 level GERM class</p>
+<p class="requirement-sec-3"> a 300 or 400 level MODL class as approved by the undergraduate advisor</p>
+<p class="requirement-sec-3"> from a class with a German studies focus in English, History, Music, Political Science, Philosophy, Art History, Theater as approved by the undergraduate advisor. Specific classes that may be used to fulfill this requirement are:</p>
+<p class="requirement-sec-4">AHIS 226 Northern Renaissance Art</p>
+<p class="requirement-sec-4">AHIS 426 Northern Renaissance &amp; Reformation Art</p>
+<p class="requirement-sec-4">AHIS 498 Special Problems: German Film &amp; Art between the Wars</p>
+<p class="requirement-sec-4">HIST 327 19th Century Germany</p>
+<p class="requirement-sec-4">HIST 328 History of Germany, 1914-present</p>
+<p class="requirement-sec-4">HIST 339 The Holocaust</p>
+<p class="requirement-sec-4">HIST 421 The German Reformation (Cross-listed with German)</p>
+<p class="requirement-sec-4">HIST 429 History of Fascism in Europe</p>
+<p class="requirement-sec-4">MUSC 442 Great Composers</p>
+<p class="requirement-sec-4">PHIL 333 History of Philosophy</p>
+<p class="requirement-sec-4">PHIL 345 Modern European Jewish Philosophy</p>
+<p class="requirement-sec-4">PHIL 471 Kant</p>
+<p class="requirement-sec-4">POLS 371 The Politics of the European Union</p>
+<p class="requirement-sec-4">(Classes in Film Studies offered through the Department of English are possible in consultation with instructor and German Section.)</p>
+<p class="header-paragraph-title">Program Assessment.</span> <span class="header-paragraph">In order to assist the department in evaluating the effectiveness of its programs, majors will be required to assemble and maintain a portfolio. In their junior year, majors will be assigned a faculty adviser who will inform students of the required contents of the portfolio, deadlines and procedures. By their senior year, majors will be required to complete a taped oral proficiency interview.</span></p>
 <p class="basic-text">Results of participation in this assessment activity will in no way affect a student’s GPA or graduation.</p>
 
 <p><span class="header-paragraph-title"></span></p>

--- a/data/2015/majors/German (ASC).xhtml
+++ b/data/2015/majors/German (ASC).xhtml
@@ -47,14 +47,14 @@
 <p class="title-1">Specific Major Requirements:</p>
 
 <p class="requirement-sec-1">27 hours (of courses numbered 300 or above)</p>
-<p class="requirement-sec-2">Core: GERM 301, GERM 302, GERM 303, GERM 304, GERM 403</p>
-<p class="requirement-sec-2">3 additional hours of elective GERM courses at 300 level or above (these may include German classes offered in English)</p>
-<p class="requirement-sec-2">6 additional hours of elective GERM courses at 400 level</p>
-<p class="requirement-sec-2">3 additional elective credit hours. These 3 hours may be from:</p>
+<p class="requirement-sec-2">– Core: GERM 301, GERM 302, GERM 303, GERM 304, GERM 403</p>
+<p class="requirement-sec-2">– 3 additional hours of elective GERM courses at 300 level or above (these may include German classes offered in English)</p>
+<p class="requirement-sec-2">– 6 additional hours of elective GERM courses at 400 level</p>
+<p class="requirement-sec-2">– 3 additional elective credit hours. These 3 hours may be from:</p>
 
-<p class="requirement-sec-3"> a 300 or 400 level GERM class</p>
-<p class="requirement-sec-3"> a 300 or 400 level MODL class as approved by the undergraduate advisor</p>
-<p class="requirement-sec-3"> from a class with a German studies focus in English, History, Music, Political Science, Philosophy, Art History, Theater as approved by the undergraduate advisor. Specific classes that may be used to fulfill this requirement are:</p>
+<p class="requirement-sec-3"> - a 300 or 400 level GERM class</p>
+<p class="requirement-sec-3"> - a 300 or 400 level MODL class as approved by the undergraduate advisor</p>
+<p class="requirement-sec-3"> - from a class with a German studies focus in English, History, Music, Political Science, Philosophy, Art History, Theater as approved by the undergraduate advisor. Specific classes that may be used to fulfill this requirement are:</p>
 <p class="requirement-sec-4">AHIS 226 Northern Renaissance Art</p>
 <p class="requirement-sec-4">AHIS 426 Northern Renaissance &amp; Reformation Art</p>
 <p class="requirement-sec-4">AHIS 498 Special Problems: German Film &amp; Art between the Wars</p>
@@ -69,7 +69,7 @@
 <p class="requirement-sec-4">PHIL 471 Kant</p>
 <p class="requirement-sec-4">POLS 371 The Politics of the European Union</p>
 <p class="requirement-sec-4">(Classes in Film Studies offered through the Department of English are possible in consultation with instructor and German Section.)</p>
-<p class="header-paragraph-title">Program Assessment.</span> <span class="header-paragraph">In order to assist the department in evaluating the effectiveness of its programs, majors will be required to assemble and maintain a portfolio. In their junior year, majors will be assigned a faculty adviser who will inform students of the required contents of the portfolio, deadlines and procedures. By their senior year, majors will be required to complete a taped oral proficiency interview.</span></p>
+<p class="header-paragraph-title">Program Assessment. <span class="header-paragraph">In order to assist the department in evaluating the effectiveness of its programs, majors will be required to assemble and maintain a portfolio. In their junior year, majors will be assigned a faculty adviser who will inform students of the required contents of the portfolio, deadlines and procedures. By their senior year, majors will be required to complete a taped oral proficiency interview.</span></p>
 <p class="basic-text">Results of participation in this assessment activity will in no way affect a student’s GPA or graduation.</p>
 
 <p><span class="header-paragraph-title"></span></p>

--- a/data/2015/majors/German (ASC).xhtml
+++ b/data/2015/majors/German (ASC).xhtml
@@ -46,35 +46,29 @@
 <p class="content-box-h-1">MAJOR REQUIREMENTS</p>
 <p class="title-1">Specific Major Requirements:</p>
 
-<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">27 hours (of courses numbered 300 or above).</p>
-<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">• Core: GERM 301, GERM 302, GERM 303, GERM 304, GERM 403</p>
-<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">• 3 additional hours of elective GERM courses at 300 level or above (these may include</p>
-<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">GERM classes offered in English)</p>
-<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">• 6 additional hours of elective GERM courses at 400 level.</p>
-<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">• 3 additional elective credit hours. These 3 hours may be from:</p>
-<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">- a 300 or 400 level GERM class,</p>
-<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">- a 300 or 400 level MODL class as approved by the undergraduate advisor.</p>
-<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">- from a class with a German studies focus in English, History, Music, Political</p>
-<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">Science, Philosophy, Art History, Theater as approved by the undergraduate</p>
-<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">advisor. Specific classes that me be used to fulfill this requirement are:</p>
-<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">AHIS 226 Northern Renaissance Art</p>
-<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">AHIS 426 Northern Renaissance and Reformation Art</p>
-<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">AHIS 498 Special Problems: German Film and art between the Wars</p>
-<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">HIST 327 19th Century Germany</p>
-<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">HIST 328 History of Germany, 1914-present</p>
-<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">HIST 339 The Holocaust</p>
-<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">HIST 421 The German Reformation (Cross-listed with German)</p>
-<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">HIST 429 History of Fascism in Europe</p>
-<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">MUSC 442 Great Composers</p>
-<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">PHIL 333 History of Philosophy</p>
-<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">PHIL 345 Modern European Jewish Philosophy</p>
-<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">PHIL 471 Kant</p>
-<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">POLS 371 The Politics of the European Union</p>
+<p class="requirement-sec-1">27 hours (of courses numbered 300 or above)</p>
+
+<p><span class="requirement-sec-2">Core: GERM 301, GERM 302, GERM 303, GERM 304, GERM 403</span><br /><span class="requirement-sec-2">3 additional hours of elective GERM courses at 300 level or above (these may include</span> German<span class="requirement-sec-2"> classes offered in English)</span><br /><span class="requirement-sec-2" style="font-family: Helvetica; font-size: 11px;">6 additional hours of elective GERM courses at 400 level</span><br /><span class="requirement-sec-2" style="font-family: Helvetica; font-size: 11px;">3 additional elective credit hours. These 3 hours may be from:</span></p>
+
+<p class="requirement-sec-3" style="margin: 0px; font-size: 11px; font-family: Helvetica;"> a 300 or 400 level GERM class,</p>
+<p class="requirement-sec-3" style="margin: 0px; font-size: 11px; font-family: Helvetica;"> a 300 or 400 level MODL class as approved by the undergraduate advisor.</p>
+<p class="requirement-sec-3" style="margin: 0px; font-size: 11px; font-family: Helvetica;"> from a class with a German studies focus in English, History, Music, Political Science, Philosophy, Art History, Theater as approved by the undergraduate advisor. Specific classes that me be used to fulfill this requirement are:</p>
+<p class="requirement-sec-4" style="margin: 0px; font-size: 11px; font-family: Helvetica;">AHIS 226 Northern Renaissance Art</p>
+<p class="requirement-sec-4" style="margin: 0px; font-size: 11px; font-family: Helvetica;">AHIS 426 Northern Renaissance &amp; Reformation Art</p>
+<p class="requirement-sec-4" style="margin: 0px; font-size: 11px; font-family: Helvetica;">AHIS 498 Special Problems: German Film &amp; Art between the Wars</p>
+<p class="requirement-sec-4" style="margin: 0px; font-size: 11px; font-family: Helvetica;">HIST 327 19th Century Germany</p>
+<p class="requirement-sec-4" style="margin: 0px; font-size: 11px; font-family: Helvetica;">HIST 328 History of Germany, 1914-present</p>
+<p class="requirement-sec-4" style="margin: 0px; font-size: 11px; font-family: Helvetica;">HIST 339 The Holocaust</p>
+<p class="requirement-sec-4" style="margin: 0px; font-size: 11px; font-family: Helvetica;">HIST 421 The German Reformation (Cross-listed with German)</p>
+<p class="requirement-sec-4" style="margin: 0px; font-size: 11px; font-family: Helvetica;">HIST 429 History of Fascism in Europe</p>
+<p class="requirement-sec-4" style="margin: 0px; font-size: 11px; font-family: Helvetica;">MUSC 442 Great Composers</p>
+<p class="requirement-sec-4" style="margin: 0px; font-size: 11px; font-family: Helvetica;">PHIL 333 History of Philosophy</p>
+<p class="requirement-sec-4" style="margin: 0px; font-size: 11px; font-family: Helvetica;">PHIL 345 Modern European Jewish Philosophy</p>
+<p class="requirement-sec-4" style="margin: 0px; font-size: 11px; font-family: Helvetica;">PHIL 471 Kant</p>
+<p class="requirement-sec-4" style="margin: 0px; font-size: 11px; font-family: Helvetica;">POLS 371 The Politics of the European Union</p>
 <p style="margin: 0px; font-size: 11px; font-family: Helvetica;">(Classes in Film Studies offered through the Department of English are possible in consultation with instructor and German Section.)</p>
-
-
-<p><strong>Program Assessment.</strong> In order to assist the department in evaluating the effectiveness of its programs, majors will be required to assemble and maintain a portfolio. In their junior year, majors will be assigned a faculty adviser who will inform students of the required contents of the portfolio, deadlines and procedures. By their senior year, majors will be required to complete a taped oral proficiency interview.</p>
-<p>Results of participation in this assessment activity will in no way affect a student’s GPA or graduation.</p>
+<p style="margin: 0px; font-size: 11px; font-family: Helvetica;"><span class="header-paragraph-title">Program Assessment.</span> <span class="header-paragraph">In order to assist the department in evaluating the effectiveness of its programs, majors will be required to assemble and maintain a portfolio. In their junior year, majors will be assigned a faculty adviser who will inform students of the required contents of the portfolio, deadlines and procedures. By their senior year, majors will be required to complete a taped oral proficiency interview.</span></p>
+<p class="basic-text">Results of participation in this assessment activity will in no way affect a student’s GPA or graduation.</p>
 
 <p><span class="header-paragraph-title"></span></p>
 <p class="content-box-h-1">ADDITIONAL MAJOR REQUIREMENTS</p>
@@ -82,7 +76,8 @@
 <p class="title-2">Pass/No Pass Limits</p>
 <p class="basic-text">No courses in the department may be taken by students majoring or minoring in modern languages for Pass/No Pass credit.</p>
 <p class="content-box-h-1">REQUIREMENTS FOR MINOR OFFERED BY DEPARTMENT</p>
-<p class="header-paragraph"><span class="header-paragraph-title">Plan A.</span> 12 hours in one language at the 300 level or 400 level, including at least 6 hours from 301, 302, 303, 304, and 3 hours at the 400 level.</p>
+<p class="title-3">Plan A</p>
+<p class="header-paragraph"><span class="header-paragraph-title"></span>12 hours in one language at the 300 level or 400 level, including at least 6 hours from 301, 302, 303, 304, and 3 hours at the 400 level.</p>
 <p class="header-paragraph"><span class="header-paragraph-title"> </span>                    </p>
 <p class="header-paragraph"><span class="header-paragraph-title">Pass/No Pass.</span> No courses in the department may be taken by students majoring or minoring in modern languages for Pass/No Pass credit.</p>
             </div>

--- a/data/2015/majors/German (ASC).xhtml
+++ b/data/2015/majors/German (ASC).xhtml
@@ -67,8 +67,8 @@
 <p class="requirement-sec-4">PHIL 333 History of Philosophy (19th Century)</p>
 <p class="requirement-sec-4">PHIL 345 Modern European Jewish Philosophy (JUDS 345)</p>
 <p class="requirement-sec-4">PHIL 471 Kant</p>
-<p class="requirement-sec-4">(Classes in Film Studies offered through the Department of English are possible in consultation with instructor and German Section.)</p>
-<p>Minor Requirements</p>
+<p class="requirement-sec-4"><span class="requirement-ital">(Classes in Film Studies offered through the Department of English are possible in consultation with instructor and German Section.)</span></p>
+<p class="title-1">Minor Requirements</p>
 <p>A minor is required and may be taken in any area.</p>
 <p class="header-paragraph"><span class="header-paragraph-title">Program Assessment.</span> In order to assist the department in evaluating the effectiveness of its programs, majors will be required to assemble and maintain a portfolio. In their junior year, majors will be assigned a faculty adviser who will inform students of the required contents of the portfolio, deadlines and procedures. By their senior year, majors will be required to complete a taped oral proficiency interview.</p>
 <p class="basic-text">Results of participation in this assessment activity will in no way affect a student’s GPA or graduation.</p>

--- a/data/2015/majors/German (ASC).xhtml
+++ b/data/2015/majors/German (ASC).xhtml
@@ -69,7 +69,7 @@
 <p class="requirement-sec-4">PHIL 471 Kant</p>
 <p class="requirement-sec-4"><span class="requirement-ital">(Classes in Film Studies offered through the Department of English are possible in consultation with instructor and German Section.)</span></p>
 <p class="title-1">Minor Requirements</p>
-<p>A minor is required and may be taken in any area.</p>
+<p class="basic-text">A minor is required and may be taken in any area.</p>
 <p class="header-paragraph"><span class="header-paragraph-title">Program Assessment.</span> In order to assist the department in evaluating the effectiveness of its programs, majors will be required to assemble and maintain a portfolio. In their junior year, majors will be assigned a faculty adviser who will inform students of the required contents of the portfolio, deadlines and procedures. By their senior year, majors will be required to complete a taped oral proficiency interview.</p>
 <p class="basic-text">Results of participation in this assessment activity will in no way affect a student’s GPA or graduation.</p>
 

--- a/data/2015/majors/German (ASC).xhtml
+++ b/data/2015/majors/German (ASC).xhtml
@@ -2,11 +2,11 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <title>German (ASC) 14-15.xhtml</title>
+        <title>German (ASC) 15-16.xhtml</title>
         <link href="template.css" rel="stylesheet" type="text/css" />
     </head>
     <body>
-        <div id="german-asc-14-15">
+        <div id="german-asc-15-16">
             <div class="generated-style">
                 <p class="major-name">German (ASC)</p>
             </div>
@@ -44,21 +44,45 @@
 <p class="basic-text">The Department offers the following literature in translation courses for which no knowledge of a foreign language is necessary. Check the Schedule of Classes to determine which are being taught in any given semester: MODL 234D Major Themes in World Literature; MODL 298, MODL 398 Special Topics; FREN 282 and GERM 282 Literature in Translation; SPAN 264 and SPAN 265 Spanish-American Literature in Translation I &amp; II; MODL/GERM 442/842 Survey of Medieval German Literature in Translation; JAPN 331 Introduction to Japanese Film; JAPN 483 Japanese Literature in Translation; and RUSS 482 and RUSS 483 Russian Literature in Translation I &amp; II.</p>
 <p class="header-paragraph"><span class="header-paragraph-title">Graduate Work.</span> The advanced degrees of master of arts and doctor of philosophy are offered in French, German, and Spanish. For details, see the <span class="basic-text-ital">Graduate Studies Bulletin</span>.</p>
 <p class="content-box-h-1">MAJOR REQUIREMENTS</p>
-<p class="title-1">Specific Major Requirements</p>
+<p class="title-1">Specific Major Requirements:</p>
+
+<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">27 hours (of courses numbered 300 or above).</p>
+<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">• Core: GERM 301, GERM 302, GERM 303, GERM 304, GERM 403</p>
+<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">• 3 additional hours of elective GERM courses at 300 level or above (these may include</p>
+<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">GERM classes offered in English)</p>
+<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">• 6 additional hours of elective GERM courses at 400 level.</p>
+<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">• 3 additional elective credit hours. These 3 hours may be from:</p>
+<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">- a 300 or 400 level GERM class,</p>
+<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">- a 300 or 400 level MODL class as approved by the undergraduate advisor.</p>
+<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">- from a class with a German studies focus in English, History, Music, Political</p>
+<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">Science, Philosophy, Art History, Theater as approved by the undergraduate</p>
+<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">advisor. Specific classes that me be used to fulfill this requirement are:</p>
+<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">AHIS 226 Northern Renaissance Art</p>
+<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">AHIS 426 Northern Renaissance and Reformation Art</p>
+<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">AHIS 498 Special Problems: German Film and art between the Wars</p>
+<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">HIST 327 19th Century Germany</p>
+<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">HIST 328 History of Germany, 1914-present</p>
+<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">HIST 339 The Holocaust</p>
+<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">HIST 421 The German Reformation (Cross-listed with German)</p>
+<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">HIST 429 History of Fascism in Europe</p>
+<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">MUSC 442 Great Composers</p>
+<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">PHIL 333 History of Philosophy</p>
+<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">PHIL 345 Modern European Jewish Philosophy</p>
+<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">PHIL 471 Kant</p>
+<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">POLS 371 The Politics of the European Union</p>
+<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">(Classes in Film Studies offered through the Department of English are possible</p>
+
+<p style="margin: 0px; font-size: 11px; font-family: Helvetica;">in consultation with instructor and German Section</p>
 <ul>
-<li>20 hours of courses numbered 300 or above including GERM 301, GERM 302, GERM 303 and GERM 304, and 6 hours at the 400 level.</li>
+<li><span class="header-paragraph-title"></span></li>
 </ul>
-<p class="header-paragraph"><span class="header-paragraph-title">Program Assessment.</span> In order to assist the department in evaluating the effectiveness of its programs, majors will be required to assemble and maintain a portfolio. In their junior year, majors will be assigned a faculty adviser who will inform students of the required contents of the portfolio, deadlines and procedures. By their senior year, majors will be required to complete a taped oral proficiency interview.</p>
-<p class="basic-text">Results of participation in this assessment activity will in no way affect a student’s GPA or graduation.</p>
-<p class="title-1">Minor Requirements</p>
-<p class="basic-text">A minor is required and may be taken in any area.</p>
 <p class="content-box-h-1">ADDITIONAL MAJOR REQUIREMENTS</p>
 <p class="title-1">Grade Rules</p>
 <p class="title-2">Pass/No Pass Limits</p>
 <p class="basic-text">No courses in the department may be taken by students majoring or minoring in modern languages for Pass/No Pass credit.</p>
 <p class="content-box-h-1">REQUIREMENTS FOR MINOR OFFERED BY DEPARTMENT</p>
 <p class="header-paragraph"><span class="header-paragraph-title">Plan A.</span> 12 hours in one language at the 300 level or 400 level, including at least 6 hours from 301, 302, 303, 304, and 3 hours at the 400 level.</p>
-<p class="header-paragraph"><span class="header-paragraph-title">Plan B.</span> 6 hours in one language, in courses numbered above 300, including at least 3 hours from 301, 302, 303, 304.</p>
+<p class="header-paragraph"><span class="header-paragraph-title"> </span>                    </p>
 <p class="header-paragraph"><span class="header-paragraph-title">Pass/No Pass.</span> No courses in the department may be taken by students majoring or minoring in modern languages for Pass/No Pass credit.</p>
             </div>
         </div>


### PR DESCRIPTION
Updating bulletin section.

Expanding the major by 6 hours with the option of taking a 3 hour class on a German studies related subject outside DMLL allows us to bring more breadth to the major without requiring additional resources.

GERM 403 guarantees that majors will take an upper division class focused on solidifying language skills and expanding mastery of semantic and syntactic structures before graduating from the program. Adding an additional required 400 level class assures that majors take at least two upper division literature classes. In addition to this expanded breadth of content, students' writing, and speaking skills will improve with this additional requirement.


All majors in MLL either have or are in the process of eliminating Plan B minors at the request of the college.



 
