### PR TITLE
Finalize Request #8598

### DIFF
--- a/data/2015/majors/Digital Humanities Minor.xhtml
+++ b/data/2015/majors/Digital Humanities Minor.xhtml
@@ -43,8 +43,8 @@
 <p class="requirement-sec-2">HIST 470 Digital History</p>
 <p class="title-3">Electives (choose any two elective courses for 6 credit hours)</p>
 <p class="requirement-sec-2">ANTH 386 Digital Heritage Tools</p>
-<p class="requirement-sec-2">CLAS 490 Doing Digital Classics: Theory, Approaches, and Research Methods</p>
-<p class="requirement-sec-2">COMM 250 Rhetoric, Media, and Civic Life</p>
+<p class="requirement-sec-2">CLAS 490 Doing Digital Classics: Theory, Approaches, &amp; Research Methods</p>
+<p class="requirement-sec-2">COMM 250 Rhetoric, Media, &amp; Civic Life</p>
 <p class="requirement-sec-2">CSCE 101 Fundamentals of Computer Science</p>
 <p class="requirement-sec-2">CSCE 155 Computer Science I</p>
 <p class="requirement-sec-2">CSCE 311 Data Structures &amp; Algorithms for Informatics</p>
@@ -64,7 +64,7 @@
 <p class="requirement-sec-2">GEOG 432 GIS Programming for Advanced Spatial Analysis &amp; Modeling</p>
 <p class="requirement-sec-2">HIST 305 Digital America</p>
 <p class="requirement-sec-2">HIST 470 Digital History</p>
-<p class="requirement-sec-2">SPAN 478 Introduction to Digital Analysis and Hispanic Cultures</p>
+<p class="requirement-sec-2">SPAN 478 Introduction to Digital Analysis &amp; Hispanic Cultures</p>
 <p class="requirement-sec-2">STAT 218 Introduction to Statistics</p>
 <p class="requirement-sec-2">STAT 318 Introduction to Statistics II</p>
 <p class="requirement-sec-2">THEA 282 Digital Video Production</p>

--- a/data/2015/majors/Digital Humanities Minor.xhtml
+++ b/data/2015/majors/Digital Humanities Minor.xhtml
@@ -33,15 +33,15 @@
 <li>A course may be used to satisfy either the core requirement or the electives requirement but not both.</li>
 <li>Other courses, not listed as electives, particularly special topics courses or honors courses with a relevant focus may be applied toward the minor by permission of the Faculty Director.</li>
 </ul>
-<p class="title-2">Core Courses (6 credit hours, required)</p>
+<p class="title-3">Core Courses (6 credit hours, required)</p>
 <p class="requirement-sec-2">ENGL 277 Being Human in a Digital Age (HIST 277)</p>
 
 <p class="requirement-sec-2">ENGL 472 Digital Humanities Practicum (HIST 472)</p>
-<p class="requirement-sec-2">Core Electives (choose any two courses for 6 credit hours)</p>
+<p class="title-3">Core Electives (choose any two courses for 6 credit hours)</p>
 <p class="requirement-sec-2">ENGL 278 Introduction to Digital Humanities</p>
 <p class="requirement-sec-2">ENGL 478 Digital Archives &amp; Editions</p>
 <p class="requirement-sec-2">HIST 470 Digital History</p>
-<p class="title-2">Electives (choose any two elective courses for 6 credit hours)</p>
+<p class="title-3">Electives (choose any two elective courses for 6 credit hours)</p>
 <p class="requirement-sec-2">ANTH 386 Digital Heritage Tools</p>
 <p class="requirement-sec-2">CLAS 490 Doing Digital Classics: Theory, Approaches, and Research Methods</p>
 <p class="requirement-sec-2">COMM 250 Rhetoric, Media, and Civic Life</p>
@@ -50,8 +50,8 @@
 <p class="requirement-sec-2">CSCE 311 Data Structures &amp; Algorithms for Informatics</p>
 <p class="requirement-sec-2">ENGL 278 Introduction to Digital Humanities</p>
 <p class="requirement-sec-2">ENGL 279 Digital Literary Analysis</p>
-<p class="requirement-sec-2">ENGL 378 Theorizing the Digital</p>
 <p class="requirement-sec-2">ENGL 375 Literary Studies in the Digital Age</p>
+<p class="requirement-sec-2">ENGL 378 Theorizing the Digital (HIST 378)</p>
 <p class="requirement-sec-2">ENGL 379 Reading Technologies from Antiquity to the Digital Age</p>
 <p class="requirement-sec-2">ENGL 477 Advanced Topics in Digital Humanities</p>
 <p class="requirement-sec-2">ENGL 478 Digital Archives &amp; Editions</p>

--- a/data/2015/majors/Digital Humanities Minor.xhtml
+++ b/data/2015/majors/Digital Humanities Minor.xhtml
@@ -17,9 +17,10 @@
                 <p class="quick-points"><span class="quick-point-bold">HOURS REQUIRED:</span> 18</p>
                 <p class="quick-points"><span class="quick-point-bold">MINIMUM CUMULATIVE GPA:</span> </p>
                 <p class="quick-points"><span class="quick-point-bold">MINOR AVAILABLE:</span> Yes</p>
-                <p class="quick-points"><span class="quick-point-bold">ADVISOR:</span> Matthew Jockers</p>
+                <p class="quick-points"><span class="quick-point-bold">CHIEF ADVISER:</span> Andrew Jewell and Elizabeth Lorang</p>
 <p class="content-box-h-1">DESCRIPTION</p>
-<p class="basic-text">The interdisciplinary minor in Digital Humanities addresses the demand for graduates proficient and versed in a combination of humanistic and digital/computational skills and able to work either in the realm of humanities research and teaching or in the emerging job markets of information management and online content delivery. Graduates with a minor in Digital Humanities are well positioned for project management and leadership positions in emerging digital, multimedia, and database-driven projects and industries; digitally savvy humanities majors offer an informed middle-ground between programmers, technical writers, new media artists, and researchers. Graduates remaining in academic settings are well suited to all manner of digital initiatives electronic publishing, online archiving, data management, media preservation, text analysis, and digital heritage are but a few examples.</p>
+<p>The minor in Digital Humanities offers a wide range of courses that allow students to explore how digital technologies alter our understanding of ourselves, our art, our history, and our culture. Students learn how to critically engage with digital media, and many courses introduce students to digital techniques for research, analysis, and publication. Each student gains experience with hands-on, creative digital work, and several courses provide students opportunities to conceive and build digital projects independently and with teams of other students. The range of electives available for the Digital Humanities minor, combined with frequent special topics courses that can easily be substituted in, means that students can find distinctive groups of courses that speak to their interests in literature, history, archeology, classics, art history, 3D modeling, text analysis, digital archives, and more. Graduates with a Digital Humanities minor are well prepared for a growing number of careers in industry, non-profit, and educational sectors that welcome digital skills alongside the communication and critical thinking abilities that have long been valued in humanities students. Students have also gone on to pursue graduate school in the humanities or library and information science, among other disciplines.</p>
+
 <p class="content-box-h-1">REQUIREMENTS FOR MINOR OFFERED BY DEPARTMENT</p>
 <ul>
 <li>18 hours of course work with the following distribution</li>
@@ -34,20 +35,25 @@
 </ul>
 <p class="title-2">Core Courses (6 credit hours, required)</p>
 <p class="requirement-sec-2">ENGL 277 Being Human in a Digital Age (HIST 277)</p>
-<p class="requirement-sec-2">ENGL 495 Internship in English (Digital Humanities Practicum)/HIST 397 Special Topics in History (Digital Humanities Practicum)</p>
-<p class="title-2">Core Electives (choose any two courses for 6 credit hours)</p>
+
+<p class="requirement-sec-2">ENGL 472 Digital Humanities Practicum (HIST 472)</p>
+<p class="requirement-sec-2">Core Electives (choose any two courses for 6 credit hours)</p>
 <p class="requirement-sec-2">ENGL 278 Introduction to Digital Humanities</p>
 <p class="requirement-sec-2">ENGL 478 Digital Archives &amp; Editions</p>
 <p class="requirement-sec-2">HIST 470 Digital History</p>
 <p class="title-2">Electives (choose any two elective courses for 6 credit hours)</p>
+<p class="requirement-sec-2">ANTH 386 Digital Heritage Tools</p>
+<p class="requirement-sec-2">CLAS 490 Doing Digital Classics: Theory, Approaches, and Research Methods</p>
+<p class="requirement-sec-2">COMM 250 Rhetoric, Media, and Civic Life</p>
 <p class="requirement-sec-2">CSCE 101 Fundamentals of Computer Science</p>
 <p class="requirement-sec-2">CSCE 155 Computer Science I</p>
 <p class="requirement-sec-2">CSCE 311 Data Structures &amp; Algorithms for Informatics</p>
 <p class="requirement-sec-2">ENGL 278 Introduction to Digital Humanities</p>
-<p class="requirement-sec-2">ENGL 375 Theorizing the Digital</p>
-<p class="requirement-sec-2">ENGL 378 Literary Studies in the Digital Age</p>
-<p class="requirement-sec-2">ENGL 379 Reading Technologies from Antiquity to the Digital Age </p>
-<p class="requirement-sec-2">ENGL 477 Advanced Topics in Digital Humanities </p>
+<p class="requirement-sec-2">ENGL 279 Digital Literary Analysis</p>
+<p class="requirement-sec-2">ENGL 378 Theorizing the Digital</p>
+<p class="requirement-sec-2">ENGL 375 Literary Studies in the Digital Age</p>
+<p class="requirement-sec-2">ENGL 379 Reading Technologies from Antiquity to the Digital Age</p>
+<p class="requirement-sec-2">ENGL 477 Advanced Topics in Digital Humanities</p>
 <p class="requirement-sec-2">ENGL 478 Digital Archives &amp; Editions</p>
 <p class="requirement-sec-2">GEOG 312 Introduction to Geospatial Information Sciences (NRES 312)</p>
 <p class="requirement-sec-2">GEOG 412 Introduction to Geographic Information Systems (NRES 412)</p>
@@ -56,7 +62,9 @@
 <p class="requirement-sec-2">GEOG 422 Advanced Techniques in Geographic Information Systems</p>
 <p class="requirement-sec-2">GEOG 427 Introduction to the Global Positioning System (GPS) (NRES 427)</p>
 <p class="requirement-sec-2">GEOG 432 GIS Programming for Advanced Spatial Analysis &amp; Modeling</p>
-<p class="requirement-sec-2">HIST 470 Digital History </p>
+<p class="requirement-sec-2">HIST 305 Digital America</p>
+<p class="requirement-sec-2">HIST 470 Digital History</p>
+<p class="requirement-sec-2">SPAN 478 Introduction to Digital Analysis and Hispanic Cultures</p>
 <p class="requirement-sec-2">STAT 218 Introduction to Statistics</p>
 <p class="requirement-sec-2">STAT 318 Introduction to Statistics II</p>
 <p class="requirement-sec-2">THEA 282 Digital Video Production</p>


### PR DESCRIPTION
Updating bulletin section.

A couple of notes for the updates to the courses listed as Electives: all courses listed are from departments represented on the Digital Humanities Curriculum Committee, and the committee approved the addition of these courses at a March 3, 2105, meeting. The addition of COMM 250 is at the request of new DH Curriculum Committee member, Prof. Damien Pfister, who is the instructor of the course. The committee unanimously approved its addition.

Some of the new courses listed may still be in the approval process, but we understand that all the major hurdles have been crossed and they will soon be fully approved.

The change in course numbers for a handful of courses reflect changes we understand have already been requested and we are attempting to keep everything consistent.