### PR TITLE
Finalize Request #8503

### DIFF
--- a/data/2015/majors/Russian (ASC).xhtml
+++ b/data/2015/majors/Russian (ASC).xhtml
@@ -44,27 +44,35 @@
 <p class="basic-text">The Department offers the following literature in translation courses for which no knowledge of a foreign language is necessary. Check the Schedule of Classes to determine which are being taught in any given semester: MODL 234D Major Themes in World Literature; MODL 298, MODL 398 Special Topics; FREN 282 and GERM 282 Literature in Translation; SPAN 264 and SPAN 265 Spanish-American Literature in Translation I &amp; II; MODL/GERM 442/842 Survey of Medieval German Literature in Translation; JAPN 331 Introduction to Japanese Film; JAPN 483 Japanese Literature in Translation; and RUSS 482 and RUSS 483 Russian Literature in Translation I &amp; II.</p>
 <p class="header-paragraph"><span class="header-paragraph-title">Graduate Work.</span> The advanced degrees of master of arts and doctor of philosophy are offered in French, German, and Spanish. For details, see the <span class="basic-text-ital">Graduate Studies Bulletin</span>.</p>
 <p class="content-box-h-1">MAJOR REQUIREMENTS</p>
-<p class="title-1">Specific Major Requirements</p>
-<ul>
-<li>21 hours of courses numbered 300 or above, including RUSS 303 and RUSS 304 and 6 hours at the 400 level.</li>
-</ul>
-<p class="header-paragraph"><span class="header-paragraph-title">Program Assessment.</span> In order to assist the department in evaluating the effectiveness of its programs, majors will be required to assemble and maintain a portfolio. In their junior year, majors will be assigned a faculty adviser who will inform students of the required contents of the portfolio, deadlines and procedures. During their last semester, French and Russian majors will be required to provide oral and written assessment for their portfolios.</p>
-<p class="basic-text">Results of participation in this assessment activity will in no way affect a student’s GPA or graduation.</p>
-<p class="title-1">Minor Requirements</p>
-<p class="basic-text">A minor is required and may be taken in any area.</p>
+
+<p>MAJOR REQUIREMENTS</p>
+<p>Specific Major Requirements</p>
+<p>27 hours of courses numbered 300 or above with at least 6 hours at the 400 level.</p>
+<p>15 hours of RUSS 301, RUSS 302, RUSS 303, RUSS 304 and RUSS 408</p>
+<p>6 additional hours of RUSS courses above 300</p>
+<p>6 hours of Russian Area Studies from the following list or as approved by the Chief Advisor:</p>
+<p>HIST 330</p>
+<p>HIST 338</p>
+<p>HIST 362</p>
+<p>HIST 462</p>
+<p>POLS 372</p>
+<p>POLS 462</p>
+<p>Minor Requirement</p>
+<p>A minor is required and may be taken in any area.</p>
+<p><strong>Program Assessment.</strong> In order to assist the department in evaluating the effectiveness of its programs, majors will be required to assemble a portfolio. A faculty advisor will inform students of the required contents of the portfolio, deadlines and procedures. During their last semester, Russian majors will be required to provide oral and written materials for their portfolios.</p>
+<p>Results of participation in this assessment activity will in no way affect a student’s GPA or graduation.</p>
+<p><span class="header-paragraph-title"></span></p>
 <p class="content-box-h-1">ADDITIONAL MAJOR REQUIREMENTS</p>
 <p class="title-1">Grade Rules</p>
 <p class="title-2">Pass/No Pass Limits</p>
 <p class="basic-text">No courses in the department may be taken by students majoring or minoring in modern languages for Pass/No Pass credit.</p>
 <p class="content-box-h-1">REQUIREMENTS FOR MINOR OFFERED BY DEPARTMENT</p>
-<p class="title-3">Plan A</p>
+
 <ul>
 <li>12 hours in one language at the 300 level or 400 level, including at least 6 hours from 301, 302, 303, 304, and 3 hours at the 400 level.</li>
 </ul>
-<p class="title-3">Plan B</p>
-<ul>
-<li>6 hours in one language, in courses numbered above 300, including at least 3 hours from 301, 302, 303, 304.</li>
-</ul>
+
+<ul></ul>
 <p class="header-paragraph"><span class="header-paragraph-title">Pass/No Pass.</span> No courses in the department may be taken by students majoring or minoring in modern languages for Pass/No Pass credit.</p>
             </div>
         </div>

--- a/data/2015/majors/Russian (ASC).xhtml
+++ b/data/2015/majors/Russian (ASC).xhtml
@@ -41,26 +41,35 @@
 <p class="basic-text">Students may receive full credit at the University of Nebraska for education abroad programs in many countries, among these are Costa Rica, France, Germany, Spain, Russia, Japan, and the Czech Republic. See http://educationabroad.unl.edu for a guide to these programs.</p>
 <p class="header-paragraph"><span class="header-paragraph-title">Auditing.</span> Audits are allowed in 101 in French, German and Spanish only upon recommendation of the Modern Language Placement Advisers. Otherwise no audits are allowed in 100- and 200-level classes.</p>
 <p class="title-2">Literature in Translation</p>
-<p class="basic-text">The Department offers the following literature in translation courses for which no knowledge of a foreign language is necessary. Check the Schedule of Classes to determine which are being taught in any given semester: MODL 234D Major Themes in World Literature; MODL 298, MODL 398 Special Topics; FREN 282 and GERM 282 Literature in Translation; SPAN 264 and SPAN 265 Spanish-American Literature in Translation I &amp; II; MODL/GERM 442/842 Survey of Medieval German Literature in Translation; JAPN 331 Introduction to Japanese Film; JAPN 483 Japanese Literature in Translation; and RUSS 482 and RUSS 483 Russian Literature in Translation I &amp; II.</p>
+<p class="basic-text">The Department offers the following literature in translation courses for which no knowledge of a foreign language is necessary. Check the Schedule of Classes to determine which are being taught in any given semester:</p>
+<p class="requirement-sec-2">MODL 234D Major Themes in World Literature</p>
+<p class="requirement-sec-2">MODL 298 &amp; MODL 398 Special Topics</p>
+<p class="requirement-sec-2">FREN 282 French Literature in Translation</p>
+<p class="requirement-sec-2">GERM 282 German Literature in Translation</p>
+<p class="requirement-sec-2">SPAN 264 &amp; SPAN 265 Spanish-American Literature in Translation I &amp; II</p>
+<p class="requirement-sec-2">MODL 442/GERM 442 Survey of Medieval German Literature in Translation</p>
+<p class="requirement-sec-2">JAPN 331 Introduction to Japanese Film</p>
+<p class="requirement-sec-2">JAPN 483 Japanese Literature in Translation</p>
+<p class="basic-text"><span class="requirement-sec-2">RUSS 482 </span>&amp;<span class="requirement-sec-2"> RUSS 483 Russian Literature in Translation I &amp; II</span></p>
 <p class="header-paragraph"><span class="header-paragraph-title">Graduate Work.</span> The advanced degrees of master of arts and doctor of philosophy are offered in French, German, and Spanish. For details, see the <span class="basic-text-ital">Graduate Studies Bulletin</span>.</p>
 <p class="content-box-h-1">MAJOR REQUIREMENTS</p>
 
 
-<p>Specific Major Requirements</p>
+<p class="title-1">Specific Major Requirements</p>
 <p>27 hours of courses numbered 300 or above with at least 6 hours at the 400 level.</p>
 <p>15 hours of RUSS 301, RUSS 302, RUSS 303, RUSS 304 and RUSS 408</p>
 <p>6 additional hours of RUSS courses above 300</p>
 <p>6 hours of Russian Area Studies from the following list or as approved by the major advisor:</p>
-<p>HIST 330</p>
-<p>HIST 338</p>
-<p>HIST 362</p>
-<p>HIST 462</p>
+<p class="requirement-sec-2">HIST 330</p>
+<p class="requirement-sec-2">HIST 338</p>
+<p class="requirement-sec-2">HIST 362</p>
+<p class="requirement-sec-2">HIST 462</p>
 
 
-<p><strong>Program Assessment.</strong> In order to assist the department in evaluating the effectiveness of its programs, majors will be required to assemble a portfolio. A faculty advisor will inform students of the required contents of the portfolio, deadlines and procedures. During their last semester, Russian majors will be required to provide oral and written materials for their portfolios.</p>
-<p>Results of participation in this assessment activity will in no way affect a student’s GPA or graduation.</p>
-<p>Minor Requirement</p>
-<p>A minor is required and may be taken in any area.</p>
+<p><span class="header-paragraph-title">Program Assessment. </span><span class="header-paragraph">In order to assist the department in evaluating the effectiveness of its programs, majors will be required to assemble a portfolio. A faculty advisor will inform students of the required contents of the portfolio, deadlines and procedures. During their last semester, Russian majors will be required to provide oral and written materials for their portfolios.</span></p>
+<p class="basic-text">Results of participation in this assessment activity will in no way affect a student’s GPA or graduation.</p>
+<p class="section-1">Minor Requirement</p>
+<p class="basic-text">A minor is required and may be taken in any area.</p>
 <p><span class="header-paragraph-title"></span></p>
 <p class="content-box-h-1">ADDITIONAL MAJOR REQUIREMENTS</p>
 <p class="title-1">Grade Rules</p>

--- a/data/2015/majors/Russian (ASC).xhtml
+++ b/data/2015/majors/Russian (ASC).xhtml
@@ -50,7 +50,7 @@
 <p class="requirement-sec-2">MODL 442/GERM 442 Survey of Medieval German Literature in Translation</p>
 <p class="requirement-sec-2">JAPN 331 Introduction to Japanese Film</p>
 <p class="requirement-sec-2">JAPN 483 Japanese Literature in Translation</p>
-<p class="basic-text"><span class="requirement-sec-2">RUSS 482 </span>&amp;<span class="requirement-sec-2"> RUSS 483 Russian Literature in Translation I &amp; II</span></p>
+<p><span class="requirement-sec-2">RUSS 482 &amp; RUSS 483 Russian Literature in Translation I &amp; II</span></p>
 <p class="header-paragraph"><span class="header-paragraph-title">Graduate Work.</span> The advanced degrees of master of arts and doctor of philosophy are offered in French, German, and Spanish. For details, see the <span class="basic-text-ital">Graduate Studies Bulletin</span>.</p>
 <p class="content-box-h-1">MAJOR REQUIREMENTS</p>
 

--- a/data/2015/majors/Russian (ASC).xhtml
+++ b/data/2015/majors/Russian (ASC).xhtml
@@ -50,13 +50,12 @@
 <p>27 hours of courses numbered 300 or above with at least 6 hours at the 400 level.</p>
 <p>15 hours of RUSS 301, RUSS 302, RUSS 303, RUSS 304 and RUSS 408</p>
 <p>6 additional hours of RUSS courses above 300</p>
-<p>6 hours of Russian Area Studies from the following list or as approved by the Chief Advisor:</p>
+<p>6 hours of Russian Area Studies from the following list or as approved by the major advisor:</p>
 <p>HIST 330</p>
 <p>HIST 338</p>
 <p>HIST 362</p>
 <p>HIST 462</p>
-<p>POLS 372</p>
-<p>POLS 462</p>
+
 
 <p><strong>Program Assessment.</strong> In order to assist the department in evaluating the effectiveness of its programs, majors will be required to assemble a portfolio. A faculty advisor will inform students of the required contents of the portfolio, deadlines and procedures. During their last semester, Russian majors will be required to provide oral and written materials for their portfolios.</p>
 <p>Results of participation in this assessment activity will in no way affect a student’s GPA or graduation.</p>

--- a/data/2015/majors/Russian (ASC).xhtml
+++ b/data/2015/majors/Russian (ASC).xhtml
@@ -45,7 +45,7 @@
 <p class="header-paragraph"><span class="header-paragraph-title">Graduate Work.</span> The advanced degrees of master of arts and doctor of philosophy are offered in French, German, and Spanish. For details, see the <span class="basic-text-ital">Graduate Studies Bulletin</span>.</p>
 <p class="content-box-h-1">MAJOR REQUIREMENTS</p>
 
-<p>MAJOR REQUIREMENTS</p>
+
 <p>Specific Major Requirements</p>
 <p>27 hours of courses numbered 300 or above with at least 6 hours at the 400 level.</p>
 <p>15 hours of RUSS 301, RUSS 302, RUSS 303, RUSS 304 and RUSS 408</p>
@@ -57,10 +57,11 @@
 <p>HIST 462</p>
 <p>POLS 372</p>
 <p>POLS 462</p>
-<p>Minor Requirement</p>
-<p>A minor is required and may be taken in any area.</p>
+
 <p><strong>Program Assessment.</strong> In order to assist the department in evaluating the effectiveness of its programs, majors will be required to assemble a portfolio. A faculty advisor will inform students of the required contents of the portfolio, deadlines and procedures. During their last semester, Russian majors will be required to provide oral and written materials for their portfolios.</p>
 <p>Results of participation in this assessment activity will in no way affect a student’s GPA or graduation.</p>
+<p>Minor Requirement</p>
+<p>A minor is required and may be taken in any area.</p>
 <p><span class="header-paragraph-title"></span></p>
 <p class="content-box-h-1">ADDITIONAL MAJOR REQUIREMENTS</p>
 <p class="title-1">Grade Rules</p>

--- a/data/2015/majors/Russian (ASC).xhtml
+++ b/data/2015/majors/Russian (ASC).xhtml
@@ -50,7 +50,7 @@
 <p class="requirement-sec-2">MODL 442/GERM 442 Survey of Medieval German Literature in Translation</p>
 <p class="requirement-sec-2">JAPN 331 Introduction to Japanese Film</p>
 <p class="requirement-sec-2">JAPN 483 Japanese Literature in Translation</p>
-<p><span class="requirement-sec-2">RUSS 482 &amp; RUSS 483 Russian Literature in Translation I &amp; II</span></p>
+<p class="requirement-sec-2">RUSS 482 &amp; RUSS 483 Russian Literature in Translation I &amp; II</p>
 <p class="header-paragraph"><span class="header-paragraph-title">Graduate Work.</span> The advanced degrees of master of arts and doctor of philosophy are offered in French, German, and Spanish. For details, see the <span class="basic-text-ital">Graduate Studies Bulletin</span>.</p>
 <p class="content-box-h-1">MAJOR REQUIREMENTS</p>
 


### PR DESCRIPTION
Expanding the major by 6 hours brings more depth to the major.  Encompasses courses on films, history, politics, international relations and others, as approved by the major adviser, related to Russian studies. There are many professors in the university system teaching courses which could be included in the list of "Russian Studies" courses.  Develop cross-listed courses and establish ties with other departments.  Make the students more well-rounded as they embark on their career.  NOTE:  Eliminating the Plan B minor.