### PR TITLE
Finalize Request #8599

### DIFF
--- a/data/2015/majors/Physics.xhtml
+++ b/data/2015/majors/Physics.xhtml
@@ -160,7 +160,8 @@
 <p class="requirement-sec-2">PHYS 211, PHYS 221, PHYS 212, PHYS 222 <span class="faculty-list-bold">or</span> PHYS 141, PHYS 142</p>
 <p class="requirement-sec-2">PHYS 213</p>
 
-<p class="requirement-sec-2">Plus PHYS 223 and 3 additional hours chosen from physics courses listed as requirements for the major in physics, or ASTR 204 and ASTR 224.</p>
+<p class="requirement-sec-2">PHYS 223</p>
+<p class="requirement-sec-2">3 additional hours chosen from physics courses listed as requirements for the major in physics, or ASTR 204 and ASTR 224.</p>
 
 
 <p class="requirement-sec-2"><span class="faculty-list-bold"></span></p>

--- a/data/2015/majors/Physics.xhtml
+++ b/data/2015/majors/Physics.xhtml
@@ -17,16 +17,21 @@
                 <p class="quick-points"><span class="quick-point-bold">HOURS REQUIRED:</span> 120</p>
                 <p class="quick-points"><span class="quick-point-bold">MINIMUM CUMULATIVE GPA:</span> 2.0 for graduation</p>
                 <p class="quick-points"><span class="quick-point-bold">MINOR AVAILABLE:</span> Yes</p>
-                <p class="quick-points"><span class="quick-point-bold">ADVISOR:</span> Kenneth Bloom</p>
+                <p class="quick-points"><span class="quick-point-bold">CHIEF ADVISER:</span> Kenneth Bloom</p>
 <p class="content-box-h-1">DESCRIPTION</p>
 <p class="faculty-list"><span class="faculty-list-bold">Chair: Daniel R. Claes,</span> 208 Jorgensen Hall</p>
 <p class="faculty-list"><span class="faculty-list-bold">Vice Chair:</span> Bradley Shadwick, 208 Jorgensen Hall</p>
 <p class="faculty-list"><span class="faculty-list-bold">Professors:</span> Batelaan, Claes, Dowben, Ducharme, Fabrikant, Gay, Gruverman, Liou, Schmidt, Sellmyer, Snow, Starace, Tsymbal, Umstadter</p>
 <p class="faculty-list"><span class="faculty-list-bold">Associate Professors:</span> Adenwalla, Belashchenko, Binek, Bloom, Centurion, Dominguez, Enders, Kravchenko, Shadwick, Uiterwaal</p>
 <p class="faculty-list"><span class="faculty-list-bold">Assistant Professors:</span> Fuchs, Hong, Kovalev, Xu</p>
-<p class="faculty-list"><span class="faculty-list-bold">Research Associate Professors:</span> Banerjee, Bettis, Burton, Chen, Kalmykov, Lee, Malik, Skomski, Sokolov</p>
-<p class="faculty-list"><span class="faculty-list-bold">Lecturers:</span> Jensen, Yenen</p>
-<p class="basic-text">The Department of Physics and Astronomy offers programs leading to the bachelor of arts and bachelor of science degrees. Students preparing for either graduate study or a professional career in physics should pursue the bachelor of science degree (Professional Track described below). For students who have special interests, the Department offers additional tracks in optics and lasers, materials physics, and computational physics. The interdisciplinary bachelor of science degree in the area of engineering physics is offered through the College of Engineering.</p>
+<p class="faculty-list"><span class="faculty-list-bold"></span></p>
+<p class="faculty-list">Research Professors: Skomski</p>
+<p class="faculty-list">Research Associate Professors: Banerjee, Bettis, Lee, Y. Liu</p>
+<p class="faculty-list">Research Assistant Professors: Burton, Chen, Kalmykov, Komesu, Ngoko Djiokap, Paudel, Sokolov</p>
+<p class="faculty-list">Senior Research Associates: Balasubramanian, Bose, C. Liu, Ratnikov, Zhang</p>
+
+<p class="faculty-list"><span class="faculty-list-bold">Lecturers:</span> Yenen</p>
+<p class="basic-text">The Department of Physics and Astronomy offers programs leading to the bachelor of arts and bachelor of science degrees. Students preparing for either graduate study or a professional career in physics should pursue the bachelor of science degree (Professional Track described below). For students who have special interests, the Department offers additional tracks in optics and lasers, materials physics, and computational physics. </p>
 <p class="basic-text">The courses required for the bachelor of arts degree in physics offer a broader program in science and the liberal arts suitable for a variety of preprofessional curricula and for interdisciplinary studies in areas including biophysics, chemical physics, and geophysics. Students in this degree program should select elective courses in consultation with their advisors.</p>
 <p class="basic-text">Further details concerning the Department’s undergraduate programs are given on the Departmental Web page, http://physics.unl.edu/. See the Department’s chief undergraduate advisor, Associate Professor Kenneth Bloom, 258E Jorgensen Hall.</p>
 <p class="header-paragraph"><span class="header-paragraph-title">Graduate Work.</span> The advanced degrees of master of science and doctor of philosophy are offered. For details of these programs, see the <span class="basic-text-ital">Graduate Studies Bulletin</span>.</p>
@@ -114,11 +119,11 @@
 <p class="requirement-sec-2">PHYS 442 Experimental Physics II (3 hr)</p>
 <p class="requirement-sec-2">PHYS 462 Atoms, Nuclei &amp; Elementary Particles (3 hr)</p>
 <p class="requirement-sec-2">MATH 314 Linear Algebra (3 hr) <span class="requirement-bold">or</span> MATH 424 Introduction to Partial Differential Equations (3 hr)</p>
-<p class="title-2">III. Materials Physics Track – BS ONLY (18 hrs)</p>
+<p class="title-2">III. Materials Physics Track – BS ONLY (20 hrs)</p>
 <p class="basic-text">The Materials Physics Track (for the physics B.S.) is designed for students intending to pursue graduate study or employment in Materials Physics or in related disciplines.</p>
-<p class="basic-text-no-indent"><span class="basic-text-ital">The following <span class="requirement-underline">required</span> courses are listed in the recommended sequence. <span class="basic-text-bold">(15 hrs)</span></span></p>
+<p class="basic-text-no-indent"><span class="basic-text-ital">The following <span class="requirement-underline">required</span> courses are listed in the recommended sequence. <span class="basic-text-bold">(17 hrs)</span></span></p>
 <p class="requirement-sec-2">CHEM 114 Fundamental Chemistry II (3 hr)</p>
-<p class="requirement-sec-2">CHEM 116 Quantitative Chemistry Lab (2 hr)</p>
+<p class="requirement-sec-2">CHEM 221 Elementary Quantitative Analysis (4 hr)</p>
 <p class="requirement-sec-2">MATL 360 Elements of Materials Science (4 hr)</p>
 <p class="requirement-sec-2">MATL 462 X-ray Diffraction <span class="faculty-list-bold">or</span> MATL 471 Electron Microscopy of Materials (3 hr)</p>
 <p class="requirement-sec-2">PHYS 422 Introduction to Physics &amp; Chemistry of Solids (ELEC 422) (3 hr)</p>
@@ -127,7 +132,9 @@
 <p class="requirement-sec-2">CHEM 261 Organic Chemistry (3 hr)</p>
 <p class="requirement-sec-2">CHEM 481 Physical Chemistry I (4 hr)</p>
 <p class="requirement-sec-2">ELEC 216 Electronics &amp; Circuits II (3 hr)</p>
+<p class="requirement-sec-2">PHYS 343 Physics of Lasers &amp; Modern Optics (3 hr)</p>
 <p class="requirement-sec-2">PHYS 401 Computational Physics (3 hr)</p>
+<p class="requirement-sec-2">PHYS 441 Experimental Physics I (3 hr)</p>
 <p class="title-2">IV. Computational Physics Track – BS ONLY (17 hr)</p>
 <p class="basic-text">The Computational Physics Track (for the physics B.S.) is designed for students intending to pursue graduate study or employment in Computational Physics or in related disciplines.</p>
 <p class="basic-text-no-indent"><span class="basic-text-ital">The following <span class="requirement-underline">required</span> courses are listed in the recommended sequence. <span class="basic-text-bold">(11 hrs)</span></span></p>
@@ -141,33 +148,36 @@
 <p class="requirement-sec-2">CSCE 310 Data Structures &amp; Algorithms (3 hr)</p>
 <p class="requirement-sec-2">CSCE 340 Numerical Analysis I (MATH 340) (3 hr)</p>
 <p class="requirement-sec-2">CSCE 456 Parallel Programming (3 hr)</p>
+<p class="requirement-sec-2">PHYS 343 Physics of Lasers &amp; Modern Optics (3 hr)</p>
+<p class="requirement-sec-2">PHYS 441 Experimental Physics I (3 hr)</p>
 <p class="content-box-h-1">ADDITIONAL MAJOR REQUIREMENTS</p>
 <p class="title-1">Grade Rules</p>
 <p class="title-2">Pass/No Pass Limits</p>
 <p class="basic-text">Students majoring in physics may not take any course from the list of core courses or from the list of track courses for Pass/No Pass credit. Students who are getting a minor in physics may not take any courses listed as requirements for the Plan A or Plan B minors for Pass/No Pass credit.</p>
 <p class="content-box-h-1">REQUIREMENTS FOR MINOR OFFERED BY DEPARTMENT</p>
-<p class="title-3">Plan AI. (19 hrs)</p>
+<p class="title-3">Plan A. (19 hrs)</p>
 <p class="requirement-sec-2">PHYS 201</p>
 <p class="requirement-sec-2">PHYS 211, PHYS 221, PHYS 212, PHYS 222 <span class="faculty-list-bold">or</span> PHYS 141, PHYS 142</p>
 <p class="requirement-sec-2">PHYS 213</p>
-<p class="requirement-sec-2">PHYS 223</p>
-<p class="requirement-sec-2">Plus 3 additional hours chosen from physics courses listed as requirements for the major in physics.</p>
-<p class="title-3">Plan AII. (22 hrs)</p>
+
+<p class="requirement-sec-2">Plus PHYS 223 and 3 additional hours chosen from physics courses listed as requirements for the major in physics, or ASTR 204 and ASTR 224.</p>
+
+
+<p class="requirement-sec-2"><span class="faculty-list-bold"></span></p>
+
+
+
+
+
+<p class="title-3">Plan B. (15 hrs)</p>
 <p class="requirement-sec-2">PHYS 201</p>
 <p class="requirement-sec-2">PHYS 211, PHYS 221, PHYS 212, PHYS 222 <span class="faculty-list-bold">or</span> PHYS 141, PHYS 142</p>
 <p class="requirement-sec-2">PHYS 213</p>
-<p class="requirement-sec-2">ASTR 204</p>
-<p class="requirement-sec-2">ASTR 224</p>
-<p class="requirement-sec-2">Plus one course from ASTR 403, ASTR 404, ASTR 405, ASTR 407.</p>
-<p class="title-3">Plan BI. (15 hrs)</p>
-<p class="requirement-sec-2">PHYS 201</p>
-<p class="requirement-sec-2">PHYS 211, PHYS 221, PHYS 212, PHYS 222 <span class="faculty-list-bold">or</span> PHYS 141, PHYS 142</p>
-<p class="requirement-sec-2">PHYS 213</p>
-<p class="title-3">Plan BII. (15 hrs)</p>
-<p class="requirement-sec-2">PHYS 201</p>
-<p class="requirement-sec-2">PHYS 211, PHYS 221, PHYS 212, PHYS 222 <span class="faculty-list-bold">or</span> PHYS 141, PHYS 142</p>
-<p class="requirement-sec-2">ASTR 204</p>
-<p class="requirement-sec-2">ASTR 224</p>
+
+
+<p class="requirement-sec-2"><span class="faculty-list-bold"></span></p>
+
+
 <p class="header-paragraph"><span class="header-paragraph-title">Pass/No Pass.</span> Students majoring in physics may not take any course from the list of core courses or from the list of track courses for Pass/No Pass credit. Students who are getting a minor in physics may not take any courses listed as requirements for the Plan A or Plan B minors for Pass/No Pass credit.</p>
             </div>
         </div>

--- a/data/2015/majors/Physics.xhtml
+++ b/data/2015/majors/Physics.xhtml
@@ -25,10 +25,10 @@
 <p class="faculty-list"><span class="faculty-list-bold">Associate Professors:</span> Adenwalla, Belashchenko, Binek, Bloom, Centurion, Dominguez, Enders, Kravchenko, Shadwick, Uiterwaal</p>
 <p class="faculty-list"><span class="faculty-list-bold">Assistant Professors:</span> Fuchs, Hong, Kovalev, Xu</p>
 <p class="faculty-list"><span class="faculty-list-bold"></span></p>
-<p class="faculty-list">Research Professors: Skomski</p>
-<p class="faculty-list">Research Associate Professors: Banerjee, Bettis, Lee, Y. Liu</p>
-<p class="faculty-list">Research Assistant Professors: Burton, Chen, Kalmykov, Komesu, Ngoko Djiokap, Paudel, Sokolov</p>
-<p class="faculty-list">Senior Research Associates: Balasubramanian, Bose, C. Liu, Ratnikov, Zhang</p>
+<p class="faculty-list"><span class="faculty-list-bold">Research Professor:</span> Skomski</p>
+<p class="faculty-list"><span class="faculty-list-bold">Research Associate Professors:</span> Banerjee, Bettis, Lee, Y. Liu</p>
+<p class="faculty-list"><span class="faculty-list-bold">Research Assistant Professors:</span> Burton, Chen, Kalmykov, Komesu, Ngoko Djiokap, Paudel, Sokolov</p>
+<p class="faculty-list"><span class="faculty-list-bold">Senior Research Associates:</span> Balasubramanian, Bose, C. Liu, Ratnikov, Zhang</p>
 
 <p class="faculty-list"><span class="faculty-list-bold">Lecturers:</span> Yenen</p>
 <p class="basic-text">The Department of Physics and Astronomy offers programs leading to the bachelor of arts and bachelor of science degrees. Students preparing for either graduate study or a professional career in physics should pursue the bachelor of science degree (Professional Track described below). For students who have special interests, the Department offers additional tracks in optics and lasers, materials physics, and computational physics. </p>
@@ -62,7 +62,7 @@
 <p class="requirement-sec-2">MATH 106 Calculus I (5 hr)</p>
 <p class="requirement-sec-2">PHYS 211 General Physics I <span class="requirement-ital">(preferred)</span> (4 hr) &amp; PHYS 221 General Physics Lab I <span class="requirement-ital">(preferred)</span> (1 hr) <span class="requirement-bold">or</span> PHYS 141 Elementary General Physics I (5 hr)</p>
 <p class="requirement-sec-2">MATH 107 Calculus II (4 hr)</p>
-<p class="requirement-sec-2">CHEM 113 Fundamental Chemistry I <span class="requirement-ital">(preferred)</span> <span class="requirement-bold">or</span> CHEM 111 Chemistry for Engineering &amp; Technology <span class="requirement-bold">or</span> CHEM 109 General Chemistry I (4)</p>
+<p class="requirement-sec-2">CHEM 113 Fundamental Chemistry I <span class="requirement-ital">(preferred)</span> <span class="requirement-bold">or</span> CHEM 111 Chemistry for Engineering &amp; Technology <span class="requirement-bold">or</span> CHEM 109 General Chemistry I (4 hr)</p>
 <p class="requirement-sec-2">PHYS 212 General Physics II <span class="requirement-ital">(preferred)</span> (4 hr) &amp; PHYS 222 General Physics Laboratory II <span class="requirement-ital">(preferred)</span> (1 hr) <span class="requirement-bold">or</span> PHYS 142 Elementary General Physics II (5 hr)</p>
 <p class="requirement-sec-2">MATH 208 Calculus III (4 hr)</p>
 <p class="requirement-sec-2">PHYS 213 General Physics III (4 hr)</p>
@@ -76,14 +76,14 @@
 <p class="requirement-sec-2">PHYS 311 Mechanics (3 hr)</p>
 <p class="requirement-sec-2">PHYS 361 Concepts of Modern Physics (3 hr)</p>
 <p class="requirement-sec-2">PHYS 441 Experimental Physics I (3 hr)</p>
-<p class="basic-text-no-indent"><span class="basic-text-ital">In addition, at least 6 hours must be taken from the following courses <span class="requirement-bold">(6 hr)</span></span></p>
+<p class="basic-text-no-indent"><span class="basic-text-ital">In addition, at least 6 hours must be taken from the following courses. <span class="requirement-bold">(6 hr)</span></span></p>
 <p class="requirement-sec-2">PHYS 343 Physics of Lasers &amp; Modern Optics (3 hr)</p>
 <p class="requirement-sec-2">PHYS 391 Undergraduate Research (3 hr)</p>
 <p class="requirement-sec-2">PHYS 451 Electromagnetic Theory (3 hr)</p>
 <p class="requirement-sec-2">PHYS 461 Quantum Mechanics (3 hr)</p>
 <p class="requirement-sec-2">PHYS 431 Thermal Physics (3 hr)</p>
 <p class="requirement-sec-2">PHYS 480 Introduction to Lasers &amp; Laser Applications (ELEC 480) (3 hr)</p>
-<p class="basic-text-no-indent"><span class="basic-text-ital">In addition, at least 6 hours must be taken at the 300- or 400-level in mathematics, statistics, engineering, or science (including physics) <span class="requirement-bold">(6 hr)</span></span></p>
+<p class="basic-text-no-indent"><span class="basic-text-ital">In addition, at least 6 hours must be taken at the 300- or 400-level in mathematics, statistics, engineering, or science (including physics). <span class="requirement-bold">(6 hr)</span></span></p>
 <p class="title-2">I. Professional Track – BS ONLY (18 hrs)</p>
 <p class="basic-text">The Professional Track is designed for students intending to pursue graduate study or employment in physics or a related scientific or engineering discipline.</p>
 <p class="basic-text-no-indent"><span class="basic-text-ital">The following <span class="requirement-underline">required</span> courses are listed in the recommended sequence. <span class="basic-text-bold">(12 hrs)</span></span></p>
@@ -91,7 +91,7 @@
 <p class="requirement-sec-2">PHYS 442 Experimental Physics II (3 hr)</p>
 <p class="requirement-sec-2">PHYS 452 Optics &amp; Electromagnetic Waves (3 hr)</p>
 <p class="requirement-sec-2">PHYS 462 Atoms, Nuclei &amp; Elementary Particles (3 hr)</p>
-<p class="basic-text-no-indent"><span class="basic-text-ital">In addition, at least 6 hours must be taken from the following courses <span class="requirement-bold">(6 hr)</span></span></p>
+<p class="basic-text-no-indent"><span class="basic-text-ital">In addition, at least 6 hours must be taken from the following courses. <span class="requirement-bold">(6 hr)</span></span></p>
 <p class="requirement-sec-2">PHYS 343 Physics of Lasers &amp; Modern Optics (3 hr)</p>
 <p class="requirement-sec-2">PHYS 361 Concepts of Modern Physics (3 hr)</p>
 <p class="requirement-sec-2">PHYS 391 Undergraduate Research (3 hr)</p>
@@ -111,8 +111,8 @@
 <p class="requirement-sec-2">PHYS 441 Experimental Physics I (3 hr)</p>
 <p class="requirement-sec-2">PHYS 452 Optics &amp; Electromagnetic Waves (3 hr)</p>
 <p class="requirement-sec-2">PHYS 480 Introduction to Lasers &amp; Laser Applications (ELEC 480) (3 hr)</p>
-<p class="basic-text-no-indent"><span class="basic-text-ital">In addition, at least 6 hours must be taken from the following courses <span class="requirement-bold">(6 hr)</span></span></p>
-<p class="requirement-sec-2">PHYS 391 Undergraduate Research <span class="requirement-ital">(Up to 3 hours of PHYS 391 may be counted toward these 6 hours by substitution, provided that the research project is approved by the Advisor.)</span></p>
+<p class="basic-text-no-indent"><span class="basic-text-ital">In addition, at least 6 hours must be taken from the following courses. <span class="requirement-bold">(6 hr)</span></span></p>
+<p class="requirement-sec-2">PHYS 391 Undergraduate Research <span class="requirement-ital">(Up to 3 hours of PHYS 391 may be counted toward these 6 hours by substitution, provided that the research project is approved by the advisor.)</span></p>
 <p class="requirement-sec-2">PHYS 361 Concepts of Modern Physics (3 hr)</p>
 <p class="requirement-sec-2">PHYS 401 Computational Physics (3 hr)</p>
 <p class="requirement-sec-2">PHYS 422 Introduction to Physics &amp; Chemistry of Solids (ELEC 422) (3 hr)</p>
@@ -127,8 +127,8 @@
 <p class="requirement-sec-2">MATL 360 Elements of Materials Science (4 hr)</p>
 <p class="requirement-sec-2">MATL 462 X-ray Diffraction <span class="faculty-list-bold">or</span> MATL 471 Electron Microscopy of Materials (3 hr)</p>
 <p class="requirement-sec-2">PHYS 422 Introduction to Physics &amp; Chemistry of Solids (ELEC 422) (3 hr)</p>
-<p class="basic-text-no-indent"><span class="basic-text-ital">In addition, at least 3 hours must be taken from the following courses <span class="requirement-bold">(3 hr)</span></span></p>
-<p class="requirement-sec-2">PHYS 391 Undergraduate Research <span class="requirement-ital">(Up to 3 hours of PHYS 391 may be counted toward these 3 hours by substitution, provided that the research project is approved by the Advisor.)</span></p>
+<p class="basic-text-no-indent"><span class="basic-text-ital">In addition, at least 3 hours must be taken from the following courses. <span class="requirement-bold">(3 hr)</span></span></p>
+<p class="requirement-sec-2">PHYS 391 Undergraduate Research <span class="requirement-ital">(Up to 3 hours of PHYS 391 may be counted toward these 3 hours by substitution, provided that the research project is approved by the advisor.)</span></p>
 <p class="requirement-sec-2">CHEM 261 Organic Chemistry (3 hr)</p>
 <p class="requirement-sec-2">CHEM 481 Physical Chemistry I (4 hr)</p>
 <p class="requirement-sec-2">ELEC 216 Electronics &amp; Circuits II (3 hr)</p>
@@ -142,8 +142,8 @@
 <p class="requirement-sec-2">CSCE 156 Computer Science II (4 hr)</p>
 <p class="requirement-sec-2">CSCE 251 UNIX Programming Environment (1 hr) <span class="faculty-list-bold">or</span> CSCE 252A FORTRAN Programming (1 hr)</p>
 <p class="requirement-sec-2">PHYS 401 Computational Physics (3 hr)</p>
-<p class="basic-text-no-indent"><span class="basic-text-ital">In addition, at least 6 hours must be taken from the following courses <span class="requirement-bold">(6 hr)</span></span></p>
-<p class="requirement-sec-2">PHYS 391 Undergraduate Research <span class="requirement-ital">(Up to 3 hours of PHYS 391 may be counted toward these 6 hours by substitution, provided that the research project is approved by the Advisor.)</span></p>
+<p class="basic-text-no-indent"><span class="basic-text-ital">In addition, at least 6 hours must be taken from the following courses. <span class="requirement-bold">(6 hr)</span></span></p>
+<p class="requirement-sec-2">PHYS 391 Undergraduate Research <span class="requirement-ital">(Up to 3 hours of PHYS 391 may be counted toward these 6 hours by substitution, provided that the research project is approved by the advisor.)</span></p>
 <p class="requirement-sec-2">CSCE 235 Introduction to Discrete Structures (3 hr)</p>
 <p class="requirement-sec-2">CSCE 310 Data Structures &amp; Algorithms (3 hr)</p>
 <p class="requirement-sec-2">CSCE 340 Numerical Analysis I (MATH 340) (3 hr)</p>

--- a/data/2015/majors/Physics.xhtml
+++ b/data/2015/majors/Physics.xhtml
@@ -146,7 +146,7 @@
 <p class="requirement-sec-2">PHYS 391 Undergraduate Research <span class="requirement-ital">(Up to 3 hours of PHYS 391 may be counted toward these 6 hours by substitution, provided that the research project is approved by the advisor.)</span></p>
 <p class="requirement-sec-2">CSCE 235 Introduction to Discrete Structures (3 hr)</p>
 <p class="requirement-sec-2">CSCE 310 Data Structures &amp; Algorithms (3 hr)</p>
-<p class="requirement-sec-2">CSCE 340 Numerical Analysis I (MATH 340) (3 hr)</p>
+<p class="requirement-sec-2">CSCE 440 Numerical Analysis I (MATH 440) (3 hr)</p>
 <p class="requirement-sec-2">CSCE 456 Parallel Programming (3 hr)</p>
 <p class="requirement-sec-2">PHYS 343 Physics of Lasers &amp; Modern Optics (3 hr)</p>
 <p class="requirement-sec-2">PHYS 441 Experimental Physics I (3 hr)</p>


### PR DESCRIPTION
Updating bulletin section. Note small changes to the major requirements and the streamlining of the minor to a single Plan A and single Plan B. These changes have been approved by the department faculty.

In detail:
1. Kenneth Bloom is added as the Chief Adviser.
2. Changes in department personnel are indicated.
3. The College of Engineering no longer offers an interdisciplinary bachelor of science degree in engineering physics, so this sentence is removed.
4. Changes to the Materials Physics track. CHEM 116 (Quantitative Chemistry Lab -- 2 hr) is no longer offered, so we replace this with CHEM 221 (Elementary Quantitative Analysis -- 4 hr). This increases the hours in this track from 18 to 20 hours, as indicated. We also add PHYS 343 and PHYS 441 to the list of elective courses in this track, since these two courses are ACE 10 certified and we want to lead the students in this track to take one of these ACE 10 courses.
5. Changes to the Computational Physics track. For the same reason as in Item 4, we add PHYS 343 and PHYS 441 to the list of elective courses in this track, since these two courses are ACE 10 certified and we want to lead the students in this track to take one of these ACE 10 courses.
6. The streamlining of the minor has been discussed with Debbie Minter, and is now approved by the department faculty. We believe we are the only department which has had two Plan A and two Plan B minors on the books. The idea historically is that one of the Plan A and one of the Plan B minors would have an astronomy focus. In the new single Plan A and single Plan B minors, a student can choose to take some astronomy courses according to the options listed.