### PR TITLE
Finalize Request #8667

### DIFF
--- a/data/2015/majors/Latin American Studies.xhtml
+++ b/data/2015/majors/Latin American Studies.xhtml
@@ -44,19 +44,19 @@
 <p class="requirement-sec-3">SPAN 317 Introduction to Linguistics (3 cr)</p>
 <p class="requirement-sec-3">SPAN 319 Sound Systems of Spanish (3 cr)</p>
 <p class="header-paragraph"><span class="header-paragraph-title">B.</span> Courses in at least three departments from the following:</p>
-<p class="header-paragraph">ETHN 171  History of Latin America  (HIST 171) (3 cr)</p>
-<p class="header-paragraph">ETHN 333  Immigration and Politics (POLS 333)  (3 cr)</p>
+<p class="header-paragraph">ETHN 171 History of Latin America (HIST 171) (3 cr)</p>
+<p class="header-paragraph">ETHN 333 Immigration and Politics (POLS 333) (3 cr)</p>
 
 
 <p class="requirement-sec-3">ETHN 345D Chicana and/or Chicano Literature (ENGL 345D) (3 cr)</p>
 <p class="requirement-sec-3">ETHN 350 Peoples &amp; Cultures of Native Latin America (ANTH 350) (3 cr)</p>
-<p class="requirement-sec-3">ETHN 370  Colonial Mexico  (HIST 370)  (3 cr)</p>
-<p class="requirement-sec-3">ETHN 371  Modern Mexico  (HIST 371)  (3 cr)</p>
+<p class="requirement-sec-3">ETHN 370 Colonial Mexico (HIST 370) (3 cr)</p>
+<p class="requirement-sec-3">ETHN 371 Modern Mexico (HIST 371) (3 cr)</p>
 <p class="requirement-sec-3">ETHN 476A Gender &amp; Sexuality in Latin America (HIST 476A/WMNS 476A) (3 cr)</p>
 <p class="requirement-sec-3">ETHN 476B Race in Modern Latin America (HIST 476B) (3 cr)</p>
 <p class="requirement-sec-3">GEOG 378 Geography of Latin America (3 cr)</p>
 <p class="requirement-sec-3">HIST 372 Revolutions in 20th Century Latin America (3 cr)</p>
-<p class="requirement-sec-3">LAMS 237  Ancient Mesoamerica  (ANTH 237, ETHN 237) (3 cr)</p>
+<p class="requirement-sec-3">LAMS 237 Ancient Mesoamerica (ANTH 237, ETHN 237) (3 cr)</p>
 <p class="requirement-sec-3">LAMS 271 Colonial Latin America (ETHN 271/HIST 271) (3 cr)</p>
 <p class="requirement-sec-3">LAMS 272 Modern Latin America (ETHN 272/HIST 272) (3 cr)</p>
 <p class="requirement-sec-3">LAMS 277 Latin American Politics (ETHN 277/POLS 277) (3 cr)</p>
@@ -81,10 +81,10 @@
 <p class="title-3">Core Course</p>
 <p class="requirement-sec-2">ETHN 202 Introduction to Latina and/or Latino Studies (3 cr)</p>
 <p class="requirement-sec-1">At least 15 hours (from at least two departments) from the following courses (other courses may be used with the approval of the minor advisor):</p>
-<p class="requirement-sec-1">ETHN 310  Psychology of Immigration  (PSYC 310)  (3 cr)</p>
+<p class="requirement-sec-1">ETHN 310 Psychology of Immigration (PSYC 310) (3 cr)</p>
 
 <p class="requirement-sec-2">ETHN 330 Multicultural Education (TEAC 330) (3 cr)</p>
-<p class="requirement-sec-2">ETHN 333 Immigration and Politics  (POLS 333)  (3 cr)</p>
+<p class="requirement-sec-2">ETHN 333 Immigration and Politics (POLS 333) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 345D Chicana and/or Chicano Literature (ENGL 345D) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 357 Mexican-American History (HIST 357/LAMS 357) (3 cr)</p>
             </div>

--- a/data/2015/majors/Latin American Studies.xhtml
+++ b/data/2015/majors/Latin American Studies.xhtml
@@ -74,9 +74,11 @@
 <p class="content-box-h-1">REQUIREMENTS FOR MINOR OFFERED BY DEPARTMENT</p>
 <p class="title-1">Requirements for the Latin American Studies Minor</p>
 <p class="requirement-sec-1">18 hours:</p>
-<p class="requirement-sec-2">6 hrs in modern languages and literatures as in Group A courses under the major requirements</p>
-<p class="requirement-sec-2">12 hrs in social sciences as in Group B and C courses under the major requirements above</p>
-<p class="requirement-sec-2">No more than 3 hrs of LAMS 399 will count toward the minor. Minors may not take LAMS 399H for credit.</p>
+<ul>
+<li>6 hrs in modern languages and literatures as in Group A courses under the major requirements</li>
+<li>12 hrs in social sciences as in Group B and C courses under the major requirements above</li>
+<li>No more than 3 hrs of LAMS 399 will count toward the minor. Minors may not take LAMS 399H for credit.</li>
+</ul>
 <p class="header-paragraph">UNL and UNO are also jointly cooperating in our Latin American Studies minor. See discussion above.</p>
 <p class="title-1">Requirements for the U.S. Latina/Latino Studies Minor</p>
 

--- a/data/2015/majors/Latin American Studies.xhtml
+++ b/data/2015/majors/Latin American Studies.xhtml
@@ -17,9 +17,9 @@
                 <p class="quick-points"><span class="quick-point-bold">HOURS REQUIRED:</span> 120</p>
                 <p class="quick-points"><span class="quick-point-bold">MINIMUM CUMULATIVE GPA:</span> 2.0 for graduation</p>
                 <p class="quick-points"><span class="quick-point-bold">MINOR AVAILABLE:</span> Yes-Latin American Studies; U.S. Latina/Latino Studies</p>
-                <p class="quick-points"><span class="quick-point-bold">ADVISOR:</span> Jeannette Jones</p>
+                <p class="quick-points"><span class="quick-point-bold">CHIEF ADVISER:</span> </p>
 <p class="content-box-h-1">DESCRIPTION</p>
-<p class="faculty-list"><span class="faculty-list-bold">Faculty:</span> Ari (history/ethnic studies), Cantarero (community and regional planning), Castro (English/ethnic studies), Garza (history/ethnic studies), Hames (anthropology and geography), Lopez (curriculum and instruction), Mason (agronomy), Montes (English/ethnic studies), Myers (State Museum/anthropology and geography),  Osorio (veterinary science), Pereira (modern languages and literatures), Van Den Berg (economics), Wals (political science), Walters (agronomy)</p>
+<p class="faculty-list"><span class="faculty-list-bold">Faculty:</span> Ari (history/ethnic studies), Cantarero (community and regional planning), Castro (English/ethnic studies), Garza (history/ethnic studies), Hames (anthropology and geography), Lopez (curriculum and instruction), Mason (agronomy), Montes (English/ethnic studies), Myers (State Museum/anthropology and geography), Osorio (veterinary science), Pereira (modern languages and literatures), Van Den Berg (economics), Wals (political science), Walters (agronomy)</p>
 <p class="basic-text">Latino and Latin American Studies includes a major and minor in Latin American Studies and a minor in U.S. Latina/Latino Studies.</p>
 <p class="basic-text">The major and minor in Latin American Studies are designed to provide a sound basis for undergraduate students who intend to seek employment with governmental agencies and private enterprises with operations in Latin America, as well as those who decide to undertake graduate study in some academic discipline with emphasis in this area. The U.S. Latina/Latino Studies minor focuses on people of Latin American origin or descent living in the U.S.</p>
 <p class="basic-text">Many students who major in Latin American Studies carry a double major with Spanish, history, political science, economics, global studies, or international business, or have chosen to minor in one of those fields.</p>
@@ -30,7 +30,7 @@
 <p class="header-paragraph">The major will include:</p>
 <p class="header-paragraph"><span class="header-paragraph-title">A.</span> At least 9 hours selected from the following courses:</p>
 <p class="requirement-sec-3">LAMS 311 Introduction to Hispanic Literature: Latin America (SPAN 311) (3 cr)</p>
-<p class="requirement-sec-3">LAMS 312 Representative Spanish-American Authors  (SPAN 312) (3 cr)</p>
+<p class="requirement-sec-3">LAMS 312 Representative Spanish-American Authors (SPAN 312) (3 cr)</p>
 <p class="requirement-sec-3">LAMS 331 Latin American Civilization (SPAN 331) (3 cr)</p>
 <p class="requirement-sec-3">LAMS 459 Spanish-American Poetry (SPAN 459) (3 cr)</p>
 <p class="requirement-sec-3">LAMS 460 Spanish-American Novel (SPAN 460) (3 cr)</p>
@@ -42,19 +42,21 @@
 <p class="requirement-sec-3">SPAN 304 Advanced Writing (3 cr)</p>
 <p class="requirement-sec-3">SPAN 305 The Analysis of Communication in Spanish (3 cr)</p>
 <p class="requirement-sec-3">SPAN 317 Introduction to Linguistics (3 cr)</p>
-<p class="requirement-sec-3">SPAN 319 Sound Systems of Spanish  (3 cr)</p>
+<p class="requirement-sec-3">SPAN 319 Sound Systems of Spanish (3 cr)</p>
 <p class="header-paragraph"><span class="header-paragraph-title">B.</span> Courses in at least three departments from the following:</p>
-<p class="requirement-sec-3">AHIS 256 Latin American Art (3 cr)</p>
-<p class="requirement-sec-3">AHIS 457 Colonial Art of Latin America (3 cr)</p>
-<p class="requirement-sec-3">ECON 321 Introduction to International Economics (3 cr)</p>
-<p class="requirement-sec-3">ECON 322 Introduction to Development Economics (3 cr)</p>
-<p class="requirement-sec-3">ECON 323 The Economic Development of Latin America (3 cr)</p>
+<p class="header-paragraph">ETHN 171  History of Latin America  (HIST 171) (3 cr)</p>
+<p class="header-paragraph">ETHN 333  Immigration and Politics (POLS 333)  (3 cr)</p>
+
+
 <p class="requirement-sec-3">ETHN 345D Chicana and/or Chicano Literature (ENGL 345D) (3 cr)</p>
 <p class="requirement-sec-3">ETHN 350 Peoples &amp; Cultures of Native Latin America (ANTH 350) (3 cr)</p>
+<p class="requirement-sec-3">ETHN 370  Colonial Mexico  (HIST 370)  (3 cr)</p>
+<p class="requirement-sec-3">ETHN 371  Modern Mexico  (HIST 371)  (3 cr)</p>
 <p class="requirement-sec-3">ETHN 476A Gender &amp; Sexuality in Latin America (HIST 476A/WMNS 476A) (3 cr)</p>
 <p class="requirement-sec-3">ETHN 476B Race in Modern Latin America (HIST 476B) (3 cr)</p>
 <p class="requirement-sec-3">GEOG 378 Geography of Latin America (3 cr)</p>
 <p class="requirement-sec-3">HIST 372 Revolutions in 20th Century Latin America (3 cr)</p>
+<p class="requirement-sec-3">LAMS 237  Ancient Mesoamerica  (ANTH 237, ETHN 237) (3 cr)</p>
 <p class="requirement-sec-3">LAMS 271 Colonial Latin America (ETHN 271/HIST 271) (3 cr)</p>
 <p class="requirement-sec-3">LAMS 272 Modern Latin America (ETHN 272/HIST 272) (3 cr)</p>
 <p class="requirement-sec-3">LAMS 277 Latin American Politics (ETHN 277/POLS 277) (3 cr)</p>
@@ -62,7 +64,7 @@
 <p class="requirement-sec-3">LAMS 374 History of Brazil (ETHN 374/HIST 374) (3 cr)</p>
 <p class="requirement-sec-3">MNGT 414 Leadership in a Global Context (3 cr)</p>
 <p class="requirement-sec-3">MRKT 453 International Marketing (3 cr)</p>
-<p class="requirement-sec-3">TEAC 433 Comparative Education (3 cr)</p>
+
 <p class="header-paragraph"><span class="header-paragraph-title">C. Individualized Courses of Instruction.</span> A total of 9 hours of individualized course work may count towards the major, but no more than 6 hours of one particular course (i.e., LAMS 399 or LAMS 399H) will count toward the major.</p>
 <p class="header-paragraph"><span class="header-paragraph-title">D. 3 hours LAMS 478/878 Pro-Seminar in Latin American Studies</span></p>
 <p class="title-3">Minor Requirements</p>
@@ -79,8 +81,10 @@
 <p class="title-3">Core Course</p>
 <p class="requirement-sec-2">ETHN 202 Introduction to Latina and/or Latino Studies (3 cr)</p>
 <p class="requirement-sec-1">At least 15 hours (from at least two departments) from the following courses (other courses may be used with the approval of the minor advisor):</p>
-<p class="requirement-sec-2">ETHN 218 Chicanos in American Society (SOCI 218) (3 cr)</p>
+<p class="requirement-sec-1">ETHN 310  Psychology of Immigration  (PSYC 310)  (3 cr)</p>
+
 <p class="requirement-sec-2">ETHN 330 Multicultural Education (TEAC 330) (3 cr)</p>
+<p class="requirement-sec-2">ETHN 333 Immigration and Politics  (POLS 333)  (3 cr)</p>
 <p class="requirement-sec-2">ETHN 345D Chicana and/or Chicano Literature (ENGL 345D) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 357 Mexican-American History (HIST 357/LAMS 357) (3 cr)</p>
             </div>

--- a/data/2015/majors/Latin American Studies.xhtml
+++ b/data/2015/majors/Latin American Studies.xhtml
@@ -78,9 +78,10 @@
 </ul>
 <p class="header-paragraph">UNL and UNO are also jointly cooperating in our Latin American Studies minor. See discussion above.</p>
 <p class="title-1">Requirements for the U.S. Latina/Latino Studies Minor</p>
-<p class="title-3">Core Course</p>
+
+<p class="requirement-sec-2">18 hours:</p>
 <p class="requirement-sec-2">ETHN 202 Introduction to Latina and/or Latino Studies (3 cr)</p>
-<p class="requirement-sec-1">At least 15 hours (from at least two departments) from the following courses (other courses may be used with the approval of the minor advisor):</p>
+
 <p class="requirement-sec-1">ETHN 310 Psychology of Immigration (PSYC 310) (3 cr)</p>
 
 <p class="requirement-sec-2">ETHN 330 Multicultural Education (TEAC 330) (3 cr)</p>

--- a/data/2015/majors/Latin American Studies.xhtml
+++ b/data/2015/majors/Latin American Studies.xhtml
@@ -44,8 +44,8 @@
 <p class="requirement-sec-3">SPAN 317 Introduction to Linguistics (3 cr)</p>
 <p class="requirement-sec-3">SPAN 319 Sound Systems of Spanish (3 cr)</p>
 <p class="header-paragraph"><span class="header-paragraph-title">B.</span> Courses in at least three departments from the following:</p>
-<p class="header-paragraph">ETHN 171 History of Latin America (HIST 171) (3 cr)</p>
-<p class="header-paragraph">ETHN 333 Immigration and Politics (POLS 333) (3 cr)</p>
+<p class="requirement-sec-3">ETHN 171 History of Latin America (HIST 171) (3 cr)</p>
+<p class="requirement-sec-3">ETHN 333 Immigration and Politics (POLS 333) (3 cr)</p>
 
 
 <p class="requirement-sec-3">ETHN 345D Chicana and/or Chicano Literature (ENGL 345D) (3 cr)</p>
@@ -56,7 +56,7 @@
 <p class="requirement-sec-3">ETHN 476B Race in Modern Latin America (HIST 476B) (3 cr)</p>
 <p class="requirement-sec-3">GEOG 378 Geography of Latin America (3 cr)</p>
 <p class="requirement-sec-3">HIST 372 Revolutions in 20th Century Latin America (3 cr)</p>
-<p class="requirement-sec-3">LAMS 237 Ancient Mesoamerica (ANTH 237, ETHN 237) (3 cr)</p>
+<p class="requirement-sec-3">LAMS 237 Ancient Mesoamerica (ANTH 237/ETHN 237) (3 cr)</p>
 <p class="requirement-sec-3">LAMS 271 Colonial Latin America (ETHN 271/HIST 271) (3 cr)</p>
 <p class="requirement-sec-3">LAMS 272 Modern Latin America (ETHN 272/HIST 272) (3 cr)</p>
 <p class="requirement-sec-3">LAMS 277 Latin American Politics (ETHN 277/POLS 277) (3 cr)</p>
@@ -73,16 +73,17 @@
 <p class="basic-text">Results of participation in this assessment activity will in no way affect a student’s GPA or graduation.</p>
 <p class="content-box-h-1">REQUIREMENTS FOR MINOR OFFERED BY DEPARTMENT</p>
 <p class="title-1">Requirements for the Latin American Studies Minor</p>
-<ul>
-<li>18 hours: 6 hrs in modern languages and literatures as in Group A courses under the major requirements, 12 hrs in social sciences as in Group B and C courses under the major requirements above. No more than 3 hrs of LAMS 399 will count toward the minor. Minors may not take LAMS 399H for credit.</li>
-</ul>
+<p class="requirement-sec-1">18 hours:</p>
+<p class="requirement-sec-2">6 hrs in modern languages and literatures as in Group A courses under the major requirements</p>
+<p class="requirement-sec-2">12 hrs in social sciences as in Group B and C courses under the major requirements above</p>
+<p><span class="requirement-sec-2">No more than 3 hrs of LAMS 399 will count toward the minor. Minors may not take LAMS 399H for credit.</span></p>
 <p class="header-paragraph">UNL and UNO are also jointly cooperating in our Latin American Studies minor. See discussion above.</p>
 <p class="title-1">Requirements for the U.S. Latina/Latino Studies Minor</p>
 
-<p class="requirement-sec-2">18 hours:</p>
+<p class="requirement-sec-1">18 hours:</p>
 <p class="requirement-sec-2">ETHN 202 Introduction to Latina and/or Latino Studies (3 cr)</p>
 
-<p class="requirement-sec-1">ETHN 310 Psychology of Immigration (PSYC 310) (3 cr)</p>
+<p class="requirement-sec-2">ETHN 310 Psychology of Immigration (PSYC 310) (3 cr)</p>
 
 <p class="requirement-sec-2">ETHN 330 Multicultural Education (TEAC 330) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 333 Immigration and Politics (POLS 333) (3 cr)</p>

--- a/data/2015/majors/Latin American Studies.xhtml
+++ b/data/2015/majors/Latin American Studies.xhtml
@@ -76,7 +76,7 @@
 <p class="requirement-sec-1">18 hours:</p>
 <p class="requirement-sec-2">6 hrs in modern languages and literatures as in Group A courses under the major requirements</p>
 <p class="requirement-sec-2">12 hrs in social sciences as in Group B and C courses under the major requirements above</p>
-<p><span class="requirement-sec-2">No more than 3 hrs of LAMS 399 will count toward the minor. Minors may not take LAMS 399H for credit.</span></p>
+<p class="requirement-sec-2">No more than 3 hrs of LAMS 399 will count toward the minor. Minors may not take LAMS 399H for credit.</p>
 <p class="header-paragraph">UNL and UNO are also jointly cooperating in our Latin American Studies minor. See discussion above.</p>
 <p class="title-1">Requirements for the U.S. Latina/Latino Studies Minor</p>
 


### PR DESCRIPTION
Updating bulletin section.

Courses deleted from the LAMS major and US Latina/O Studies minor are no longer being taught or have not been taught for 10 or more years.(Called and confirmed this from each department.)

Courses added to the Latin American Studies major and US Latina/O Studies minor meet the curriculum for each and make additional course selection for students.



History, Anthropology, and Political Science Chairs all approved the addition of each.