### PR TITLE
Finalize Request #9075

### DIFF
--- a/data/2016/majors/Biological Sciences.xhtml
+++ b/data/2016/majors/Biological Sciences.xhtml
@@ -2,11 +2,11 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <title>Biological Sciences 15-16.xhtml</title>
+        <title>Biological Sciences 16-17.xhtml</title>
         <link href="template.css" rel="stylesheet" type="text/css" />
     </head>
     <body>
-        <div id="biological-sciences-15-16">
+        <div id="biological-sciences-16-17">
             <div class="generated-style">
                 <p class="major-name">Biological Sciences</p>
             </div>
@@ -19,11 +19,11 @@
                 <p class="quick-points"><span class="quick-point-bold">MINOR AVAILABLE:</span> Yes</p>
                 <p class="quick-points"><span class="quick-point-bold">ADVISOR:</span> Wendy O'Connor</p>
 <p class="content-box-h-1">DESCRIPTION</p>
-<p class="faculty-list"><span class="faculty-list-bold">Director: Valery E. Forbes,</span> 348 Manter Hall</p>
-<p class="faculty-list"><span class="faculty-list-bold">Vice Director:</span> John C. Osterman, 348 Manter Hall</p>
-<p class="faculty-list"><span class="faculty-list-bold">Professors:</span> Avramova, Basolo, Blum, Cerutti, Christensen, Forbes, Fritz, Gardner, Gibson, Harshman, Kamil, Knops, Morris, Nickerson, Wagner, Wood, Zera, L. Zhang</p>
-<p class="faculty-list"><span class="faculty-list-bold">Associate Professors:</span> P. Angeletti, Atkin, Bachman, Brassil, Brown, Chia, Elthon, Hebets, Li, Montooth, E. Moriyama, H. Moriyama, Osterman, Pilson, Russo, Storz, Tenhumberg, Yu</p>
-<p class="faculty-list"><span class="faculty-list-bold">Assistant Professors:</span>  Couch, DeLong, Meiklejohn, Riekhof,  Weber, C. Zhang</p>
+<p class="faculty-list"><span class="faculty-list-bold">Interim Director: John C. Osterman,</span> 402 Manter Hall</p>
+<p class="faculty-list"><span class="faculty-list-bold">Vice Director:</span> Audrey L. Atkin, 402 Manter Hall</p>
+<p class="faculty-list"><span class="faculty-list-bold">Professors:</span> Avramova, Basolo, Blum, Cerutti, Christensen, Fritz, Gardner, Gibson, Harshman, Hebets, Knops, E. Moriyama, Nickerson, Wagner, Wood, Zera, L. Zhang</p>
+<p class="faculty-list"><span class="faculty-list-bold">Associate Professors:</span> P. Angeletti, Atkin, Bachman, Brassil, Brown, Chia, Elthon, Li, Montooth,  H. Moriyama, Osterman, Pilson, Russo, Storz, Tenhumberg, Yu, C. Zhang</p>
+<p class="faculty-list"><span class="faculty-list-bold">Assistant Professors:</span> Couch, Cressler, DeLong, Meiklejohn, Riekhof, Shizuka, Weaver, Weber</p>
 <p class="faculty-list"><span class="faculty-list-bold">Professors of Practice:</span> Glider, Woodman</p>
 <p class="faculty-list"><span class="faculty-list-bold">Lecturers:</span> A. Angeletti, Herman</p>
 <p class="basic-text">The School of Biological Sciences offers educational opportunities in various areas of biology leading toward either the bachelor of science or the bachelor of arts degree. Study in the biological sciences prepares students for a variety of careers requiring knowledge of biological processes, such as teaching; environmental resource management and assessment; production and sales of biological materials; research in governmental, industrial, and academic laboratories; as well as preparation for careers in medicine, dentistry, and health-related professions.</p>
@@ -44,7 +44,7 @@
 <p class="basic-text">At least 10 hours must be at the 300 level or above, with at least two courses at the 400 level. Students concerned about their preparation for college-level biology should consult their advisor.</p>
 <p class="basic-text">Additionally, biological sciences majors are strongly urged to attend the Cedar Point Biological Station for at least one summer session. Majors are also encouraged to do a research project with a faculty member.</p>
 <p class="basic-text">No more than 8 hours may be from courses for which the home department is other than biological sciences.</p>
-<p class="basic-text">The following courses will NOT count toward the biological sciences major: BIOS 101 &amp; BIOS 101L, BIOS 150, BIOS 160, BIOS 203, BIOS 220, BIOS 222, BIOS 232 or BIOS 280. BIOS 395 Internship is offered Pass/No Pass only and therefore may not be used in the major.</p>
+<p class="basic-text">The following courses will NOT count toward the biological sciences major: BIOS 101 &amp; BIOS 101L, BIOS 117, BIOS 150, BIOS 160, BIOS 203, BIOS 220, BIOS 222, BIOS 232 or BIOS 280. BIOS 395 Internship is offered Pass/No Pass only and therefore may not be used in the major.</p>
 <p class="basic-text">No minor is required, but biological sciences majors must complete the following ancillary courses in addition to the 36 hours in the major:</p>
 <ul>
 <li>Biochemistry: BIOC 321 <span class="basic-text-bold">or</span> BIOC 431</li>

--- a/data/2016/majors/Biological Sciences.xhtml
+++ b/data/2016/majors/Biological Sciences.xhtml
@@ -60,9 +60,10 @@
 <p class="title-2">Pass/No Pass Limits</p>
 <p class="basic-text">No biological science course, except BIOS 310, used to fulfill the 36 hours for the major (and 18 hours for the minor) may be taken Pass/No Pass.</p>
 <p class="content-box-h-1">REQUIREMENTS FOR MINOR OFFERED BY DEPARTMENT</p>
-<ul>
-<li>18 hours, comprised of the five-course core: LIFE 120 &amp; LIFE 120L, LIFE 121 &amp; LIFE 121L, BIOS 205, BIOS 206, and BIOS 207</li>
-</ul>
+<p class="requirement-sec-1">18 hours, comprised of the five-course core:</p>
+<p class="requirement-sec-2">LIFE 120 &amp; LIFE 120L</p>
+<p class="requirement-sec-2">LIFE 121 &amp; LIFE 121L</p>
+<p class="requirement-sec-2">BIOS 205, BIOS 206, BIOS 207</p>
             </div>
         </div>
     </body>


### PR DESCRIPTION
Updating bulletin section.

BIOS 117 was added to courses that do not count toward the Biological Sciences Major because it is a course developed for non-majors.