### PR TITLE
Finalize Request #9354

### DIFF
--- a/data/2016/majors/Sociology.xhtml
+++ b/data/2016/majors/Sociology.xhtml
@@ -2,11 +2,11 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <title>Sociology 15-16.xhtml</title>
+        <title>Sociology 16-17.xhtml</title>
         <link href="template.css" rel="stylesheet" type="text/css" />
     </head>
     <body>
-        <div id="sociology-15-16">
+        <div id="sociology-16-17">
             <div class="generated-style">
                 <p class="major-name">Sociology</p>
             </div>
@@ -21,11 +21,11 @@
 <p class="content-box-h-1">DESCRIPTION</p>
 <p class="faculty-list"><span class="faculty-list-bold">Chair: Julia McQuillan</span>, 711 Oldfather Hall</p>
 <p class="faculty-list"><span class="faculty-list-bold">Vice-Chair:</span> Philip Schwadel</p>
-<p class="faculty-list"><span class="faculty-list-bold">Professors:</span> Deegan, Dombrowski, Hoyt, McQuillan, Moore, Tyler, Werum</p>
+<p class="faculty-list"><span class="faculty-list-bold">Professors:</span>  Dombrowski, Hoyt, McQuillan, Moore, Tyler, Werum</p>
 <p class="faculty-list"><span class="faculty-list-bold">Associate Professors:</span> Cheadle, Dance, Falci, Goosby, Kort-Butler, Olson, Schwadel, Smyth</p>
 <p class="faculty-list"><span class="faculty-list-bold">Assistant Professors:</span> Kazyak, Smith, D. Warner, T. Warner</p>
 <p class="faculty-list"><span class="faculty-list-bold">Assistant Professor of Practice:</span> Bosch</p>
-<p class="basic-text">A major in sociology within the College of Arts and Sciences (CAS) is a valuable and flexible program. The sociology curriculum provides students with vital skills, including analytical thinking, creative problem solving, effective written and oral communication, making meaning out of data through analyses, and greater understanding of social and cultural differences among people. Course choices may be made with respect to a students interests and educational objectives. Students may pursue broad training in sociology or may pursue one of our five focus areas. Focus areas include: crime/deviance, family, health, social inequality, and social research. Students are encouraged to complete an internship to apply the perspectives gained in their coursework to the real world and acquire experience in a career path.</p>
+<p class="basic-text">A major in sociology within the College of Arts and Sciences  is a valuable and flexible program. The sociology curriculum provides students with vital skills, including analytical thinking, creative problem solving, effective written and oral communication, making meaning out of data through analyses, and greater understanding of social and cultural differences among people. Course choices may be made with respect to a students interests and educational objectives. Students may pursue broad training in sociology or may pursue one of our five focus areas. Focus areas include: crime/deviance, family, health, social inequality, and social research. Students are encouraged to complete an internship to apply the perspectives gained in their coursework to the real world and acquire experience in a career path.</p>
 <p class="basic-text">Current majors and students considering a major in sociology should consult with a department advisor when registering for classes. This is particularly important because the subjects that lay the foundation for later training in sociology, plus the courses for a minor in another department, should be carefully selected. The advisor can also discuss focus areas, internships, and research opportunities.</p>
 <p class="basic-text">This department participates in the programs of Global Studies, Ethnic Studies, Environmental Studies, the Center for Great Plains Studies, the Womens and Gender Studies Program, and the Center for Civic Engagement.</p>
 <p class="basic-text">One course in rural sociology, AECN 276, may count toward a major in sociology. Students in the College of Agriculture who have taken AECN 276 may substitute the course for SOCI 101 if they plan to take other courses in the Department of Sociology.</p>
@@ -37,20 +37,20 @@
 <p>30 hours, including SOCI 101, SOCI 205, SOCI 206, SOCI 355, and a significant research experience.</p>
 </li>
 </ul>
-<p class="header-paragraph">The research experience requirement may be met in any of the following ways: 1) SOCI 310A and SOCI 310B; 2) SOCI 495; 3) SOCI 399H; or 4) SOCI 396.</p>
-<p class="header-paragraph"><span class="header-paragraph-title">Program Assessment.</span> In order to assist the department in evaluating the effectiveness of its programs, majors will be required to complete an exit survey during the course of the senior seminar. The instructor will inform the students of the scheduling and format of the survey.</p>
+<p class="header-paragraph">The research experience requirement may be met in any of the following ways: 1) SOCI 310A and SOCI 310B; 2) SOCI 495; or 3) SOCI 399H.</p>
+<p class="header-paragraph"><span class="header-paragraph-title">Program Assessment.</span> In order to assist the department in evaluating the effectiveness of its programs, majors will be asked to complete an exit survey. The Department will inform the students of the scheduling and format of the survey.  </p>
 <p class="basic-text">Results of participation in these assessment activities will not affect a students GPA or graduation in any way.</p>
 <p class="content-box-h-1">ADDITIONAL MAJOR REQUIREMENTS</p>
 <p class="title-1">Grade Rules</p>
 <p class="title-2">Pass/No Pass Limits</p>
-<p class="basic-text">Students majoring in sociology may not take courses in the major for Pass/No Pass credit with the possible exceptions of independent study, 3 credit hours of field work in sociology, and hours in excess of those required for the major. Request forms are available in the Arts and Sciences Advising Center, 107 Oldfather Hall.</p>
+<p class="basic-text">Students majoring in sociology may not take courses in the major for Pass/No Pass credit with the possible exceptions of independent study, 3 credit hours of field work in Sociology, and hours in excess of those required for the major. Request forms are available in the Arts and Sciences Advising Center, 107 Oldfather Hall.</p>
 <p class="title-1">Course Level Requirement</p>
 <p class="basic-text">At least 12 hours must be taken at the 300 or 400 level.</p>
 <p class="title-1">Extended Education, Independent Study Rules, Internship Credit Rules</p>
-<p class="basic-text">No more than 6 hours total from internship and independent study courses, SOCI 397 and SOCI 399, may be counted toward the major requirements in sociology.</p>
+<p class="basic-text">No more than 6 hours total from internship and independent study courses (SOCI396, SOCI 397, and SOCI 399) may be counted toward the major requirements in Sociology.</p>
 <p class="content-box-h-1">REQUIREMENTS FOR MINOR OFFERED BY DEPARTMENT</p>
 <ul>
-<li>18 hours including SOCI 101 and a minimum of 6 hours at the 300/400 level. No more than 3 hours total from internship and independent study courses, SOCI 397 and SOCI 399, may be counted toward the minor requirements in sociology.</li>
+<li>18 hours including SOCI 101 and a minimum of 6 hours at the 300/400 level. No more than 3 hours total from internship and independent study courses (SOCI396, SOCI 397, and SOCI 399) may be counted toward the minor requirements in Sociology.</li>
 </ul>
             </div>
         </div>

--- a/data/2016/majors/Sociology.xhtml
+++ b/data/2016/majors/Sociology.xhtml
@@ -38,7 +38,7 @@
 </li>
 </ul>
 <p class="header-paragraph">The research experience requirement may be met in any of the following ways: 1) SOCI 310A and SOCI 310B; 2) SOCI 495; or 3) SOCI 399H.</p>
-<p class="header-paragraph"><span class="header-paragraph-title">Program Assessment.</span> In order to assist the department in evaluating the effectiveness of its programs, majors will be asked to complete an exit survey. The Department will inform the students of the scheduling and format of the survey.  </p>
+<p class="header-paragraph"><span class="header-paragraph-title">Program Assessment.</span> In order to assist the department in evaluating the effectiveness of its programs, majors will be asked to complete an exit survey. The Department will inform the students of the scheduling and format of the survey. </p>
 <p class="basic-text">Results of participation in these assessment activities will not affect a students GPA or graduation in any way.</p>
 <p class="content-box-h-1">ADDITIONAL MAJOR REQUIREMENTS</p>
 <p class="title-1">Grade Rules</p>
@@ -47,10 +47,10 @@
 <p class="title-1">Course Level Requirement</p>
 <p class="basic-text">At least 12 hours must be taken at the 300 or 400 level.</p>
 <p class="title-1">Extended Education, Independent Study Rules, Internship Credit Rules</p>
-<p class="basic-text">No more than 6 hours total from internship and independent study courses (SOCI396, SOCI 397, and SOCI 399) may be counted toward the major requirements in Sociology.</p>
+<p class="basic-text">No more than 6 hours total from internship and independent study courses (SOCI 396, SOCI 397, and SOCI 399) may be counted toward the major requirements in Sociology.</p>
 <p class="content-box-h-1">REQUIREMENTS FOR MINOR OFFERED BY DEPARTMENT</p>
 <ul>
-<li>18 hours including SOCI 101 and a minimum of 6 hours at the 300/400 level. No more than 3 hours total from internship and independent study courses (SOCI396, SOCI 397, and SOCI 399) may be counted toward the minor requirements in Sociology.</li>
+<li>18 hours including SOCI 101 and a minimum of 6 hours at the 300/400 level. No more than 3 hours total from internship and independent study courses (SOCI 396, SOCI 397, and SOCI 399) may be counted toward the minor requirements in Sociology.</li>
 </ul>
             </div>
         </div>


### PR DESCRIPTION
Updating bulletin section. 
Due to forthcoming curriculum changes, SOCI 396 has been dropped from the list of courses that qualify as "significant research experience."  This course will parallel the internship and independent study courses. 