### PR TITLE
Finalize Request #9059

### DIFF
--- a/data/2016/majors/Psychology.xhtml
+++ b/data/2016/majors/Psychology.xhtml
@@ -17,7 +17,7 @@
                 <p class="quick-points"><span class="quick-point-bold">HOURS REQUIRED:</span> 120</p>
                 <p class="quick-points"><span class="quick-point-bold">MINIMUM CUMULATIVE GPA:</span> 2.0 for graduation</p>
                 <p class="quick-points"><span class="quick-point-bold">MINOR AVAILABLE:</span> Yes</p>
-                <p class="quick-points"><span class="quick-point-bold">ADVISOR:</span> Joanna Sele and Marybeth Helmink</p>
+                <p class="quick-points"><span class="quick-point-bold">ADVISOR:</span> Joanna Seley and Marybeth Helmink</p>
 <p class="content-box-h-1">DESCRIPTION</p>
 <p class="faculty-list"><span class="faculty-list-bold"></span></p>
 <p><strong>Chair</strong>: Rick Bevins, 238 Burnett Hall</p>
@@ -33,13 +33,26 @@
 <p><span class="faculty-list-bold"></span><span class="faculty-list-bold"></span><span class="faculty-list-bold"></span><span class="faculty-list-bold"></span><span class="faculty-list-bold"></span><span class="header-paragraph-title"></span><span class="basic-text-ital"></span></p>
 <p class="content-box-h-1">MAJOR REQUIREMENTS</p>
 
-<p>Specific Major Requirements (36 Total credit hours)</p>
-<p>1. PSYC 100, 181, 263, 273, 288, 289 and 350 (21 credit hours)</p>
-<p>2. 15 additional credit hours in PSYC courses numbered 300 or above, including at least 9 credit hours in 400-level courses. The following courses DO NOT fulfill this requirement: 396, 399H, 496, 497, 499.</p>
-<p>3. Students are strongly advised to complete Part 1 before beginning Part 2. </p>
-<p>Appropriate credit toward the psychology major requirements will be granted for psychology courses that are cross-listed in other departments but taken in another department. Credit toward the major will be granted even if the course is applied to another major or minor.</p>
 
-<p>Program Assessment. </p>
+
+
+
+<p>Specific Major Requirements </p>
+<p><strong> Core Requirements</strong>.……………………………………………………………...……21 </p>
+<p><span style="text-decoration: underline;">PSYC 100</span> Career Planning for Psychology Majors……..1</p>
+<p><span style="text-decoration: underline;"> PSYC 181</span> Introduction to Psychology………………… …….4 </p>
+<p><span style="text-decoration: underline;">PSYC 263</span> Introduction to Cognitive Psychology………..3 </p>
+<p><span style="text-decoration: underline;">PSYC 273</span> Brain and Behavior……………… …...3 </p>
+<p><span style="text-decoration: underline;">PSYC 288</span> Psychology of Social Behavior…………………..3 </p>
+<p><span style="text-decoration: underline;">PSYC 289</span> Developmental Psychology……………… ……….3 </p>
+<p><span style="text-decoration: underline;">PSYC 350</span> Research Methods and Analysis………………..4 </p>
+
+<p><strong>Advanced Psychology Courses</strong>……………………………………….……………..15 </p>
+<p>15 additional credit hours in PSYC courses at the 300 level or above, including at least 9 credit hours at the 400 level or above <em>(excluding PSYC 350, PSYC 396, PSYC 399H, PSYC 496, PSYC 497, PSYC 499).</em></p>
+<p><strong>Total credit hours:………….........................................………….36</strong></p>
+<p>Students are strongly advised to complete Core Requirements before the Advanced Psychology Courses.</p>
+
+<p><strong>Program Assessment. </strong></p>
 <p>To assist the department in evaluating the effectiveness of its programs, the following learning outcomes will be regularly assessed: </p>
 <p>1. Demonstrate knowledge of the main content areas of psychology, including cognitive, developmental, neuroscience and social.</p>
 <p>2. Understand the most common research designs and demonstrate ability to locate, understand, and evaluate a published research report.</p>
@@ -50,15 +63,16 @@
 <p class="content-box-h-1">ADDITIONAL MAJOR REQUIREMENTS</p>
 
 
+
 <p>Grade Rules</p>
 <p>Pass/No Pass Limits</p>
-<p>Up to 6 hours of Pass/No Pass credit may be taken in major requirements. Psychology majors may take up to 6 hours Pass/No Pass in their minor(s), subject to the approval of the department(s) granting the minor(s).</p>
+<p> Excluding PSYC 100, up to 3 hours of Pass/No Pass credit may be taken in major requirements. </p>
 
 <p class="content-box-h-1">REQUIREMENTS FOR MINOR OFFERED BY DEPARTMENT</p>
 <p class="title-2">Plan A (1 minor):</p>
 <ul>
 <li>PSYC 181</li>
-<li>14 credit hours at the 200 level or above, 9 of which must be at the 300 level or above.</li>
+<li>14 credit hours at the 200 level or above, including at least 9 credit hours at the 300 level or above.</li>
 </ul>
 <p class="requirement-sec-1">Minimum: 18 credit hours</p>
 <p class="title-2">Plan B (2 minors):</p>
@@ -68,7 +82,7 @@
 </ul>
 <p class="requirement-sec-1">Minimum: 12 credit hours.</p>
 <p class="header-paragraph">No more than 3 hours from the following courses can count toward the minor: PSYC 296, PSYC 297, PSYC 299, PSYC 396, PSYC 496, PSYC 497, PSYC 499.</p>
-<p class="header-paragraph">Students minoring in this department may take up to 6 hours Pass/No Pass.</p>
+<p class="header-paragraph">Students minoring in this department may take up to 3 hours Pass/No Pass.</p>
             </div>
         </div>
     </body>

--- a/data/2016/majors/Psychology.xhtml
+++ b/data/2016/majors/Psychology.xhtml
@@ -2,11 +2,11 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <title>Psychology 15-16.xhtml</title>
+        <title>Psychology 16-17.xhtml</title>
         <link href="template.css" rel="stylesheet" type="text/css" />
     </head>
     <body>
-        <div id="psychology-15-16">
+        <div id="psychology-16-17">
             <div class="generated-style">
                 <p class="major-name">Psychology</p>
             </div>
@@ -19,45 +19,46 @@
                 <p class="quick-points"><span class="quick-point-bold">MINOR AVAILABLE:</span> Yes</p>
                 <p class="quick-points"><span class="quick-point-bold">ADVISOR:</span> Joanna Sele and Marybeth Helmink</p>
 <p class="content-box-h-1">DESCRIPTION</p>
-<p class="faculty-list"><span class="faculty-list-bold">Chair: Rick Bevins,</span> 238 Burnett Hall</p>
-<p class="faculty-list"><span class="faculty-list-bold">Associate Chairs: </span>David DiLillo and Eve Brank, 238 Burnett Hall</p>
-<p class="faculty-list"><span class="faculty-list-bold">Professors: </span>Belli, Bevins, Bornstein, Crockett, DiLillo, Garbin, Hansen, Hope, Leger, Molfese, Pope-Edwards, Scalora, Spaulding, Tomkins, Wiener, Wilcox</p>
-<p class="faculty-list"><span class="faculty-list-bold">Associate Professors: </span>Brank, Dodd, Gervais, Li, McChargue, Schutte, Stoltenberg, Willis-Esqueda</p>
-<p class="faculty-list"><span class="faculty-list-bold">Assistant Professors: </span>Nelson, Neta, Stevens</p>
-<p class="basic-text">The undergraduate degree program in psychology is designed to provide you with educational and research experiences that can prepare you for graduate or professional school in academic psychology, medicine, dentistry, nursing, public health, and law—to name a few. The bachelors degree program in psychology can also prepare you for diverse careers in applied fields such as counseling, business, and health and human services. If you plan to major in psychology, we recommend that you meet with our advisors as early as possible to plan a program of study consistent with your interests and goals.</p>
-<p class="header-paragraph"><span class="header-paragraph-title">Graduate Work.</span> Graduate programs leading to the doctor of philosophy degree in psychology are offered. A detailed description of these courses appears in the <span class="basic-text-ital">Graduate Studies Bulletin</span>.</p>
+<p class="faculty-list"><span class="faculty-list-bold"></span></p>
+<p><strong>Chair</strong>: Rick Bevins, 238 Burnett Hall</p>
+<p><strong>Associate Chairs</strong>: David DiLillo and Eve Brank, 238 Burnett Hall</p>
+<p><strong>Professors</strong>: Belli, Bevins, Bornstein, Crockett, DiLillo, Garbin, Hansen, Hope, Leger, Molfese, Scalora, Spaulding, Tomkins, Wiener</p>
+<p><strong>Associate Professors</strong>: Brank, Dodd, Gervais, Li, McChargue, Nelson, Schutte, Stoltenberg, Willis-Esqueda</p>
+<p><strong>Assistant Professors</strong>: Brock, Johnson, Neta, Stevens</p>
+<p><strong>Assistant Professor of Practice</strong>: Williamson</p>
+
+<p>The undergraduate degree program in psychology is designed to provide you with educational and research experiences that can prepare you for graduate or professional school in academic psychology, medicine, dentistry, nursing, public health, and law—to name a few. The bachelors degree program in psychology can also prepare you for diverse careers in applied fields such as counseling, business, and health and human services. If you plan to major in psychology, we recommend that you meet with our advisors as early as possible to plan a program of study consistent with your interests and goals.</p>
+
+<p>Graduate Work. Graduate programs leading to the doctor of philosophy degree in psychology are offered. A detailed description of these courses appears in the Graduate Studies Bulletin.</p>
+<p><span class="faculty-list-bold"></span><span class="faculty-list-bold"></span><span class="faculty-list-bold"></span><span class="faculty-list-bold"></span><span class="faculty-list-bold"></span><span class="header-paragraph-title"></span><span class="basic-text-ital"></span></p>
 <p class="content-box-h-1">MAJOR REQUIREMENTS</p>
-<p class="title-1">Specific Major Requirements</p>
-<p class="requirement-sec-2">PSYC 181 4</p>
-<p class="requirement-sec-2">PSYC 100 1</p>
-<p class="requirement-sec-2"><span class="requirement-ital">Select two courses from each group below</span>: 12</p>
-<p class="requirement-sec-3">Group 1 (natural science): 6</p>
-<p class="requirement-sec-4">PSYC 233, PSYC 263, PSYC 265, PSYC 268, PSYC 270, PSYC 360, PSYC 373</p>
-<p class="requirement-sec-3">Group 2 (social science): 6</p>
-<p class="requirement-sec-4">PSYC 287, PSYC 288, PSYC 289, PSYC 380</p>
-<p class="requirement-sec-2">PSYC 350 4</p>
-<p class="requirement-sec-2"><span class="requirement-ital">Select one course from each  group below</span>: 6</p>
-<p class="requirement-sec-3">Group 1 (natural science): 3</p>
-<p class="requirement-sec-4">PSYC 456, PSYC 458, PSYC 460, PSYC 461, PSYC 463, PSYC 464, PSYC 465, PSYC 466,  BIOS 462</p>
-<p class="requirement-sec-3">Group 2 (social science): 3</p>
-<p class="requirement-sec-4">PSYC 462, PSYC 483, PSYC 485, PSYC 486, PSYC 489</p>
-<p class="requirement-sec-2">Any two additional 400-level courses 6</p>
-<p class="requirement-sec-3"><span class="requirement-ital">(excluding PSYC 496, PSYC 497, PSYC 499)</span></p>
-<p class="requirement-sec-1">Total credit hours required: 33</p>
-<p class="header-paragraph">Appropriate credit toward the psychology major requirements will be granted for psychology courses that are cross-listed in other departments but taken in another department. Credit toward the major will be granted even if the course is applied to another major or minor.</p>
-<p class="header-paragraph"><span class="header-paragraph-title">Program Assessment.</span> In order to assist the department in evaluating the effectiveness of its programs, selected psychology students will be required to:</p>
-<p class="requirement-sec-2">1. Submit copies of work produced in 200-, 300-, and 400-level courses to an assessment committee.</p>
-<p class="requirement-sec-2">2. Complete a written exit survey in their last semester.</p>
-<p class="header-paragraph">Results of participation in these assessment activities will in no way affect a student's GPA or graduation.</p>
+
+<p>Specific Major Requirements (36 Total credit hours)</p>
+<p>1. PSYC 100, 181, 263, 273, 288, 289 and 350 (21 credit hours)</p>
+<p>2. 15 additional credit hours in PSYC courses numbered 300 or above, including at least 9 credit hours in 400-level courses. The following courses DO NOT fulfill this requirement: 396, 399H, 496, 497, 499.</p>
+<p>3. Students are strongly advised to complete Part 1 before beginning Part 2. </p>
+<p>Appropriate credit toward the psychology major requirements will be granted for psychology courses that are cross-listed in other departments but taken in another department. Credit toward the major will be granted even if the course is applied to another major or minor.</p>
+
+<p>Program Assessment. </p>
+<p>To assist the department in evaluating the effectiveness of its programs, the following learning outcomes will be regularly assessed: </p>
+<p>1. Demonstrate knowledge of the main content areas of psychology, including cognitive, developmental, neuroscience and social.</p>
+<p>2. Understand the most common research designs and demonstrate ability to locate, understand, and evaluate a published research report.</p>
+<p>3. Generate a research report including the methodology and data analysis used to test an empirical hypothesis.</p>
+
+
+<p><span class="requirement-ital"></span><span class="requirement-ital"></span><span class="requirement-ital"></span><span class="header-paragraph-title"></span></p>
 <p class="content-box-h-1">ADDITIONAL MAJOR REQUIREMENTS</p>
-<p class="title-1">Grade Rules</p>
-<p class="title-2">Pass/No Pass Limits</p>
-<p class="basic-text">Up to 6 hours of Pass/No Pass credit may be taken in major requirements. Psychology majors may take up to 6 hours Pass/No Pass in their minor(s), subject to the approval of the department(s) granting the minor(s).</p>
+
+
+<p>Grade Rules</p>
+<p>Pass/No Pass Limits</p>
+<p>Up to 6 hours of Pass/No Pass credit may be taken in major requirements. Psychology majors may take up to 6 hours Pass/No Pass in their minor(s), subject to the approval of the department(s) granting the minor(s).</p>
+
 <p class="content-box-h-1">REQUIREMENTS FOR MINOR OFFERED BY DEPARTMENT</p>
 <p class="title-2">Plan A (1 minor):</p>
 <ul>
 <li>PSYC 181</li>
-<li> 14 credit hours at the 200 level or above, 9 of which must be at the 300 level or above.</li>
+<li>14 credit hours at the 200 level or above, 9 of which must be at the 300 level or above.</li>
 </ul>
 <p class="requirement-sec-1">Minimum: 18 credit hours</p>
 <p class="title-2">Plan B (2 minors):</p>
@@ -66,7 +67,7 @@
 <li>Plus three other courses at the 200 level or above.</li>
 </ul>
 <p class="requirement-sec-1">Minimum: 12 credit hours.</p>
-<p class="header-paragraph">No more than 3 hours from the following courses can count toward the minor: PSYC 296, PSYC 297, PSYC 299, PSYC 396, PSYC 496, PSYC 497,  PSYC 499.</p>
+<p class="header-paragraph">No more than 3 hours from the following courses can count toward the minor: PSYC 296, PSYC 297, PSYC 299, PSYC 396, PSYC 496, PSYC 497, PSYC 499.</p>
 <p class="header-paragraph">Students minoring in this department may take up to 6 hours Pass/No Pass.</p>
             </div>
         </div>

--- a/data/2016/majors/Psychology.xhtml
+++ b/data/2016/majors/Psychology.xhtml
@@ -19,55 +19,40 @@
                 <p class="quick-points"><span class="quick-point-bold">MINOR AVAILABLE:</span> Yes</p>
                 <p class="quick-points"><span class="quick-point-bold">ADVISOR:</span> Joanna Seley and Marybeth Helmink</p>
 <p class="content-box-h-1">DESCRIPTION</p>
-<p class="faculty-list"><span class="faculty-list-bold"></span></p>
+
 <p><strong>Chair</strong>: Rick Bevins, 238 Burnett Hall</p>
 <p><strong>Associate Chairs</strong>: David DiLillo and Eve Brank, 238 Burnett Hall</p>
 <p><strong>Professors</strong>: Belli, Bevins, Bornstein, Crockett, DiLillo, Garbin, Hansen, Hope, Leger, Molfese, Scalora, Spaulding, Tomkins, Wiener</p>
 <p><strong>Associate Professors</strong>: Brank, Dodd, Gervais, Li, McChargue, Nelson, Schutte, Stoltenberg, Willis-Esqueda</p>
 <p><strong>Assistant Professors</strong>: Brock, Johnson, Neta, Stevens</p>
 <p><strong>Assistant Professor of Practice</strong>: Williamson</p>
-
 <p>The undergraduate degree program in psychology is designed to provide you with educational and research experiences that can prepare you for graduate or professional school in academic psychology, medicine, dentistry, nursing, public health, and law—to name a few. The bachelors degree program in psychology can also prepare you for diverse careers in applied fields such as counseling, business, and health and human services. If you plan to major in psychology, we recommend that you meet with our advisors as early as possible to plan a program of study consistent with your interests and goals.</p>
-
 <p>Graduate Work. Graduate programs leading to the doctor of philosophy degree in psychology are offered. A detailed description of these courses appears in the Graduate Studies Bulletin.</p>
-<p><span class="faculty-list-bold"></span><span class="faculty-list-bold"></span><span class="faculty-list-bold"></span><span class="faculty-list-bold"></span><span class="faculty-list-bold"></span><span class="header-paragraph-title"></span><span class="basic-text-ital"></span></p>
+
 <p class="content-box-h-1">MAJOR REQUIREMENTS</p>
-
-
-
-
-
-<p>Specific Major Requirements </p>
-<p><strong> Core Requirements</strong>.……………………………………………………………...……21 </p>
+<p>Specific Major Requirements</p>
+<p><strong> Core Requirements</strong>.……………………………………………………………...……21</p>
 <p><span style="text-decoration: underline;">PSYC 100</span> Career Planning for Psychology Majors……..1</p>
-<p><span style="text-decoration: underline;"> PSYC 181</span> Introduction to Psychology………………… …….4 </p>
-<p><span style="text-decoration: underline;">PSYC 263</span> Introduction to Cognitive Psychology………..3 </p>
-<p><span style="text-decoration: underline;">PSYC 273</span> Brain and Behavior……………… …...3 </p>
-<p><span style="text-decoration: underline;">PSYC 288</span> Psychology of Social Behavior…………………..3 </p>
-<p><span style="text-decoration: underline;">PSYC 289</span> Developmental Psychology……………… ……….3 </p>
-<p><span style="text-decoration: underline;">PSYC 350</span> Research Methods and Analysis………………..4 </p>
-
-<p><strong>Advanced Psychology Courses</strong>……………………………………….……………..15 </p>
+<p><span style="text-decoration: underline;"> PSYC 181</span> Introduction to Psychology………………… …….4</p>
+<p><span style="text-decoration: underline;">PSYC 263</span> Introduction to Cognitive Psychology………..3</p>
+<p><span style="text-decoration: underline;">PSYC 273</span> Brain and Behavior……………… …...3</p>
+<p><span style="text-decoration: underline;">PSYC 288</span> Psychology of Social Behavior…………………..3</p>
+<p><span style="text-decoration: underline;">PSYC 289</span> Developmental Psychology……………… ……….3</p>
+<p><span style="text-decoration: underline;">PSYC 350</span> Research Methods and Analysis………………..4</p>
+<p><strong>Advanced Psychology Courses</strong>……………………………………….……………..15</p>
 <p>15 additional credit hours in PSYC courses at the 300 level or above, including at least 9 credit hours at the 400 level or above <em>(excluding PSYC 350, PSYC 396, PSYC 399H, PSYC 496, PSYC 497, PSYC 499).</em></p>
 <p><strong>Total credit hours:………….........................................………….36</strong></p>
 <p>Students are strongly advised to complete Core Requirements before the Advanced Psychology Courses.</p>
-
 <p><strong>Program Assessment. </strong></p>
-<p>To assist the department in evaluating the effectiveness of its programs, the following learning outcomes will be regularly assessed: </p>
+<p>To assist the department in evaluating the effectiveness of its programs, the following learning outcomes will be regularly assessed:</p>
 <p>1. Demonstrate knowledge of the main content areas of psychology, including cognitive, developmental, neuroscience and social.</p>
 <p>2. Understand the most common research designs and demonstrate ability to locate, understand, and evaluate a published research report.</p>
 <p>3. Generate a research report including the methodology and data analysis used to test an empirical hypothesis.</p>
 
-
-<p><span class="requirement-ital"></span><span class="requirement-ital"></span><span class="requirement-ital"></span><span class="header-paragraph-title"></span></p>
 <p class="content-box-h-1">ADDITIONAL MAJOR REQUIREMENTS</p>
-
-
-
 <p>Grade Rules</p>
 <p>Pass/No Pass Limits</p>
-<p> Excluding PSYC 100, up to 3 hours of Pass/No Pass credit may be taken in major requirements. </p>
-
+<p>Excluding PSYC 100, up to 3 hours of Pass/No Pass credit may be taken in major requirements.</p>
 <p class="content-box-h-1">REQUIREMENTS FOR MINOR OFFERED BY DEPARTMENT</p>
 <p class="title-2">Plan A (1 minor):</p>
 <ul>

--- a/data/2016/majors/Psychology.xhtml
+++ b/data/2016/majors/Psychology.xhtml
@@ -32,11 +32,11 @@
 <p class="requirement-sec-1">Core Requirements 21</p>
 <p class="requirement-sec-2">PSYC 100 Career Planning for Psychology Majors 1</p>
 <p class="requirement-sec-2">PSYC 181 Introduction to Psychology 4</p>
-<p class="requirement-sec-2">PSYC 263 Introduction to Cognitive Psychology 3</p>
-<p class="requirement-sec-2">PSYC 273 Brain and Behavior 3</p>
-<p class="requirement-sec-2">PSYC 288 Psychology of Social Behavior 3</p>
+<p class="requirement-sec-2">PSYC 263 Introduction to Cognitive Processes 3</p>
+<p class="requirement-sec-2">PSYC 273 Brain &amp; Behavior 3</p>
+<p class="requirement-sec-2">PSYC 288 The Psychology of Social Behavior 3</p>
 <p class="requirement-sec-2">PSYC 289 Developmental Psychology 3</p>
-<p class="requirement-sec-2">PSYC 350 Research Methods and Analysis 4</p>
+<p class="requirement-sec-2">PSYC 350 Research Methods &amp; Data Analysis 4</p>
 <p class="requirement-sec-1">Advanced Psychology Courses 15</p>
 <p class="requirement-sec-2">15 additional credit hours in PSYC courses at the 300 level or above, including at least 9 credit hours at the 400 level or above <em>(excluding PSYC 350, PSYC 396, PSYC 399H, PSYC 496, PSYC 497, PSYC 499).</em></p>
 <p class="requirement-sec-1">Total credit hours: 36</p>
@@ -63,7 +63,7 @@
 <li>Plus three other courses at the 200 level or above.</li>
 </ul>
 <p class="requirement-sec-1">Minimum: 12 credit hours.</p>
-<p class="basic-text">No more than 3 hours from the following courses can count toward the minor: PSYC 296, PSYC 297, PSYC 299, PSYC 396, PSYC 496, PSYC 497, PSYC 499. Students minoring in this department may take up to 3 hours Pass/No Pass.</p>
+<p class="header-paragraph">No more than 3 hours from the following courses can count toward the minor: PSYC 296, PSYC 297, PSYC 299, PSYC 396, PSYC 496, PSYC 497, PSYC 499. Students minoring in this department may take up to 3 hours Pass/No Pass.</p>
             </div>
         </div>
     </body>

--- a/data/2016/majors/Psychology.xhtml
+++ b/data/2016/majors/Psychology.xhtml
@@ -19,40 +19,37 @@
                 <p class="quick-points"><span class="quick-point-bold">MINOR AVAILABLE:</span> Yes</p>
                 <p class="quick-points"><span class="quick-point-bold">ADVISOR:</span> Joanna Seley and Marybeth Helmink</p>
 <p class="content-box-h-1">DESCRIPTION</p>
-
-<p><strong>Chair</strong>: Rick Bevins, 238 Burnett Hall</p>
-<p><strong>Associate Chairs</strong>: David DiLillo and Eve Brank, 238 Burnett Hall</p>
-<p><strong>Professors</strong>: Belli, Bevins, Bornstein, Crockett, DiLillo, Garbin, Hansen, Hope, Leger, Molfese, Scalora, Spaulding, Tomkins, Wiener</p>
-<p><strong>Associate Professors</strong>: Brank, Dodd, Gervais, Li, McChargue, Nelson, Schutte, Stoltenberg, Willis-Esqueda</p>
-<p><strong>Assistant Professors</strong>: Brock, Johnson, Neta, Stevens</p>
-<p><strong>Assistant Professor of Practice</strong>: Williamson</p>
-<p>The undergraduate degree program in psychology is designed to provide you with educational and research experiences that can prepare you for graduate or professional school in academic psychology, medicine, dentistry, nursing, public health, and law—to name a few. The bachelors degree program in psychology can also prepare you for diverse careers in applied fields such as counseling, business, and health and human services. If you plan to major in psychology, we recommend that you meet with our advisors as early as possible to plan a program of study consistent with your interests and goals.</p>
-<p>Graduate Work. Graduate programs leading to the doctor of philosophy degree in psychology are offered. A detailed description of these courses appears in the Graduate Studies Bulletin.</p>
-
+<p class="faculty-list"><span class="faculty-list-bold">Chair: Rick Bevins</span>, 238 Burnett Hall</p>
+<p class="faculty-list"><span class="faculty-list-bold">Associate Chairs:</span> David DiLillo and Eve Brank, 238 Burnett Hall</p>
+<p class="faculty-list"><span class="faculty-list-bold">Professors:</span> Belli, Bevins, Bornstein, Crockett, DiLillo, Garbin, Hansen, Hope, Leger, Molfese, Scalora, Spaulding, Tomkins, Wiener</p>
+<p class="faculty-list"><span class="faculty-list-bold">Associate Professors:</span> Brank, Dodd, Gervais, Li, McChargue, Nelson, Schutte, Stoltenberg, Willis-Esqueda</p>
+<p class="faculty-list"><span class="faculty-list-bold">Assistant Professors:</span> Brock, Johnson, Neta, Stevens</p>
+<p class="faculty-list"><span class="faculty-list-bold">Assistant Professor of Practice:</span> Williamson</p>
+<p class="basic-text">The undergraduate degree program in psychology is designed to provide you with educational and research experiences that can prepare you for graduate or professional school in academic psychology, medicine, dentistry, nursing, public health, and law—to name a few. The bachelors degree program in psychology can also prepare you for diverse careers in applied fields such as counseling, business, and health and human services. If you plan to major in psychology, we recommend that you meet with our advisors as early as possible to plan a program of study consistent with your interests and goals.</p>
+<p class="header-paragraph"><span class="header-paragraph-title">Graduate Work.</span> Graduate programs leading to the doctor of philosophy degree in psychology are offered. A detailed description of these courses appears in the Graduate Studies Bulletin.</p>
 <p class="content-box-h-1">MAJOR REQUIREMENTS</p>
-<p>Specific Major Requirements</p>
-<p><strong> Core Requirements</strong>.……………………………………………………………...……21</p>
-<p><span style="text-decoration: underline;">PSYC 100</span> Career Planning for Psychology Majors……..1</p>
-<p><span style="text-decoration: underline;"> PSYC 181</span> Introduction to Psychology………………… …….4</p>
-<p><span style="text-decoration: underline;">PSYC 263</span> Introduction to Cognitive Psychology………..3</p>
-<p><span style="text-decoration: underline;">PSYC 273</span> Brain and Behavior……………… …...3</p>
-<p><span style="text-decoration: underline;">PSYC 288</span> Psychology of Social Behavior…………………..3</p>
-<p><span style="text-decoration: underline;">PSYC 289</span> Developmental Psychology……………… ……….3</p>
-<p><span style="text-decoration: underline;">PSYC 350</span> Research Methods and Analysis………………..4</p>
-<p><strong>Advanced Psychology Courses</strong>……………………………………….……………..15</p>
-<p>15 additional credit hours in PSYC courses at the 300 level or above, including at least 9 credit hours at the 400 level or above <em>(excluding PSYC 350, PSYC 396, PSYC 399H, PSYC 496, PSYC 497, PSYC 499).</em></p>
-<p><strong>Total credit hours:………….........................................………….36</strong></p>
-<p>Students are strongly advised to complete Core Requirements before the Advanced Psychology Courses.</p>
-<p><strong>Program Assessment. </strong></p>
-<p>To assist the department in evaluating the effectiveness of its programs, the following learning outcomes will be regularly assessed:</p>
-<p>1. Demonstrate knowledge of the main content areas of psychology, including cognitive, developmental, neuroscience and social.</p>
-<p>2. Understand the most common research designs and demonstrate ability to locate, understand, and evaluate a published research report.</p>
-<p>3. Generate a research report including the methodology and data analysis used to test an empirical hypothesis.</p>
+<p class="title-1">Specific Major Requirements</p>
+<p class="requirement-sec-1">Core Requirements 21</p>
+<p class="requirement-sec-2">PSYC 100 Career Planning for Psychology Majors 1</p>
+<p class="requirement-sec-2">PSYC 181 Introduction to Psychology 4</p>
+<p class="requirement-sec-2">PSYC 263 Introduction to Cognitive Psychology 3</p>
+<p class="requirement-sec-2">PSYC 273 Brain and Behavior 3</p>
+<p class="requirement-sec-2">PSYC 288 Psychology of Social Behavior 3</p>
+<p class="requirement-sec-2">PSYC 289 Developmental Psychology 3</p>
+<p class="requirement-sec-2">PSYC 350 Research Methods and Analysis 4</p>
+<p class="requirement-sec-1">Advanced Psychology Courses 15</p>
+<p class="requirement-sec-2">15 additional credit hours in PSYC courses at the 300 level or above, including at least 9 credit hours at the 400 level or above <em>(excluding PSYC 350, PSYC 396, PSYC 399H, PSYC 496, PSYC 497, PSYC 499).</em></p>
+<p class="requirement-sec-1">Total credit hours: 36</p>
+<p class="header-paragraph"><span class="header-paragraph-title">NOTE:</span> Students are strongly advised to complete Core Requirements before the Advanced Psychology Courses.</p>
+<p class="header-paragraph"><span class="header-paragraph-title">Program Assessment.</span> To assist the department in evaluating the effectiveness of its programs, the following learning outcomes will be regularly assessed:</p>
+<p class="requirement-sec-2">1. Demonstrate knowledge of the main content areas of psychology, including cognitive, developmental, neuroscience and social.</p>
+<p class="requirement-sec-2">2. Understand the most common research designs and demonstrate ability to locate, understand, and evaluate a published research report.</p>
+<p class="requirement-sec-2">3. Generate a research report including the methodology and data analysis used to test an empirical hypothesis.</p>
 
 <p class="content-box-h-1">ADDITIONAL MAJOR REQUIREMENTS</p>
-<p>Grade Rules</p>
-<p>Pass/No Pass Limits</p>
-<p>Excluding PSYC 100, up to 3 hours of Pass/No Pass credit may be taken in major requirements.</p>
+<p class="title-1">Grade Rules</p>
+<p class="title-2">Pass/No Pass Limits</p>
+<p class="basic-text">Excluding PSYC 100, up to 3 hours of Pass/No Pass credit may be taken in major requirements.</p>
 <p class="content-box-h-1">REQUIREMENTS FOR MINOR OFFERED BY DEPARTMENT</p>
 <p class="title-2">Plan A (1 minor):</p>
 <ul>
@@ -66,8 +63,7 @@
 <li>Plus three other courses at the 200 level or above.</li>
 </ul>
 <p class="requirement-sec-1">Minimum: 12 credit hours.</p>
-<p class="header-paragraph">No more than 3 hours from the following courses can count toward the minor: PSYC 296, PSYC 297, PSYC 299, PSYC 396, PSYC 496, PSYC 497, PSYC 499.</p>
-<p class="header-paragraph">Students minoring in this department may take up to 3 hours Pass/No Pass.</p>
+<p class="basic-text">No more than 3 hours from the following courses can count toward the minor: PSYC 296, PSYC 297, PSYC 299, PSYC 396, PSYC 496, PSYC 497, PSYC 499. Students minoring in this department may take up to 3 hours Pass/No Pass.</p>
             </div>
         </div>
     </body>


### PR DESCRIPTION
After significant discussion, the department voted to simplify the psychology major.  The psychology major has had its current structure since at least 1980.  That structure consists of a small number of required courses and four menus of courses from which students make choices.  Because the discipline has changed significantly since 1980, we decided to revamp the requirements for the bachelor’s degree.  We believe that these changes will make advising easier and produce graduates with a more well-rounded education in psychology.  We believe that students will benefit from having a shared educational experience in taking the “core” courses.  We also think it is important that students are encouraged to take research methods and data analysis (PSYC 350) earlier in their careers and that this new major will accomplish that goal.  Earlier exposure to research methods and statistics will improve the experience of students in other courses and in whatever research experiences they undertake.  Finally, we believe that this new major, when coupled with our new learning objectives, will improve program assessment.   