### PR TITLE
Finalize Request #9222

### DIFF
--- a/data/2016/majors/Film Studies.xhtml
+++ b/data/2016/majors/Film Studies.xhtml
@@ -85,8 +85,8 @@
 <p class="requirement-sec-2">COMM 375 Theories of Persuasion (3 cr)</p>
 <p class="requirement-sec-2">COMM 380 Gender &amp; Communication (3 cr)</p>
 <p class="requirement-sec-2">COMM 398 Special Topics in Communication Studies (3 cr)</p>
-<p class="requirement-sec-2">COMM 400/800 Rhetorical Theory (3 cr)</p>
-<p class="requirement-sec-2">COMM 452/852 Media &amp; Culture (3 cr)</p>
+<p class="requirement-sec-2">COMM 400 Rhetorical Theory (3 cr)</p>
+<p class="requirement-sec-2">COMM 452 Media &amp; Culture (3 cr)</p>
 <p class="requirement-sec-2">COMM 486 Communicating Organizational Culture &amp; Power (3 cr)</p>
 <p class="requirement-sec-2">COMM 498 Special Topics in Communication Studies (3 cr)</p>
 <p class="requirement-sec-1">English</p>

--- a/data/2016/majors/Film Studies.xhtml
+++ b/data/2016/majors/Film Studies.xhtml
@@ -2,11 +2,11 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <title>Film Studies 15-16.xhtml</title>
+        <title>Film Studies 16-17.xhtml</title>
         <link href="template.css" rel="stylesheet" type="text/css" />
     </head>
     <body>
-        <div id="film-studies-15-16">
+        <div id="film-studies-16-17">
             <div class="generated-style">
                 <p class="major-name">Film Studies</p>
             </div>
@@ -60,8 +60,7 @@
 <p class="requirement-sec-2">AHIS 246 Modern Art (3 cr)</p>
 <p class="requirement-sec-2">AHIS 252 American Art 1865-1945 (3 cr)</p>
 <p class="requirement-sec-2">AHIS 346 European Art of the Twentieth Century (3 cr)</p>
-<p class="requirement-sec-2">AHIS 388 Arts of the 20th Century: 1900-1945 (MUNM 388/THEA 388) (3 cr)</p>
-<p class="requirement-sec-2">AHIS 389 Arts of the 20th Century: 1945-Present (MUNM 389/THEA 389) (3 cr)</p>
+
 <p class="requirement-sec-2">AHIS 441/841 Impressionism &amp; Post-Impressionism (3 cr)</p>
 <p class="requirement-sec-2">AHIS 446/846 Art since 1945 (3 cr)</p>
 <p class="requirement-sec-2">AHIS 448/848 Post-Modernism (3 cr)</p>


### PR DESCRIPTION
Updating bulletin section.

FPA will be eliminating Ahis 388 and 389 from its curriculum; they consider MUNM 201 as a permanent substitute. 

Please see email below from advisor Sara Fedderson: 
Kelly,
I'm not sure how involved you might be with the curriculum process in English, but now that I am starting bulletin editing for this year, I thought I would pass along a probably change in offerings.   We have a  proposal working its way through CREQ that would eliminate AHIS/MUSC/THEA 388 and 389 from existence.  Neither has been offered in at least 10 years.  MUNM 201 was the course developed to kind of replace these, and I see it is already on the list for film studies.

We might also have a new course in ceramics that would be similar to 131 and available to non-majors (131= hand building, 132= wheel throwing).  I haven't seen any details of this one yet, but things seem to be coming out quickly and in high volume lately!

On the advising side, the instructor of MUNM 275 tells me that the course will now be a summer online offering only.

And, for faculty notes on the the bulletin page, Prof. Fuller has retired.  I don't know what the process is for having faculty included in this group, but we do have two photography professors if Prof. Fuller needs to be replaced.

If you would like more updates like this, let me know and I will keep you in the loop!
Sara