### PR TITLE
Finalize Request #10483

### DIFF
--- a/data/2016/majors/Chemistry.xhtml
+++ b/data/2016/majors/Chemistry.xhtml
@@ -44,7 +44,7 @@
 <p class="requirement-sec-3">CHEM 263 Organic Chemistry Lab 2</p>
 <p class="requirement-sec-3">CHEM 264 Organic Chemistry Lab 2</p>
 <p class="requirement-sec-2">Biochemistry or Chemical Biology 5</p>
-<p class="requirement-sec-3">CHEM 431 &amp; CHEM 433 Structure &amp; Metabolism &amp; Biological Lab (5 cr) or CHEM 435 &amp; CHEM 433 Chemical Biology &amp; Biological Lab (5 cr)</p>
+<p class="requirement-sec-3">CHEM 431 &amp; CHEM 433 Structure &amp; Metabolism &amp; Biological Lab (5 cr) <span class="requirement-bold">or</span> CHEM 435 &amp; CHEM 433 Chemical Biology &amp; Biological Lab (5 cr)</p>
 <p class="requirement-sec-2">Physical Chemistry 11</p>
 <p class="requirement-sec-3">CHEM 481 Physical Chemistry I 4</p>
 <p class="requirement-sec-3">CHEM 482 Physical Chemistry II 4</p>
@@ -96,7 +96,7 @@
 <p class="content-box-h-1">ADDITIONAL MAJOR REQUIREMENTS</p>
 <p class="title-1">Grade Rules</p>
 <p class="title-2">Grades</p>
-<p class="basic-text">The grades of all Chemistry courses required for the major must be C or better. The grades of all Math and Physics courses required for the major must be C or better.</p>
+<p class="basic-text">The grades of all chemistry courses required for the major must be C or better. The grades of all math and physics courses required for the major must be C or better.</p>
 <p class="title-2">Pass/No Pass Limits</p>
 <p class="basic-text">Pass/No Pass courses are not allowed in the major or minor except for CHEM 101, CHEM 396, and/or CHEM 399.</p>
 

--- a/data/2016/majors/Chemistry.xhtml
+++ b/data/2016/majors/Chemistry.xhtml
@@ -21,7 +21,7 @@
 <p class="content-box-h-1">DESCRIPTION</p>
 <p class="faculty-list"><span class="faculty-list-bold">Chair: David Berkowitz,</span> 551 Hamilton Hall</p>
 <p class="faculty-list"><span class="faculty-list-bold">Vice Chair:</span> Jody Redepenning</p>
-<p class="faculty-list"><span class="faculty-list-bold">Professors:</span> Berkowitz, DiMagno, Du, Dussault, Eckhardt, Francisco, Hage, Harbison, Langell, Parkhurst, Powers, Rajca, Redepenning, Takacs, Zeng</p>
+<p class="faculty-list"><span class="faculty-list-bold">Professors:</span> Berkowitz, Du, Dussault, Eckhardt, Francisco, Hage, Harbison, Langell, Parkhurst, Powers, Rajca, Redepenning, Takacs, Zeng</p>
 <p class="faculty-list"><span class="faculty-list-bold">Associate Professors:</span> Cheung, Griep, Lai, Li</p>
 <p class="faculty-list"><span class="faculty-list-bold">Assistant Professors:</span> Dodds, Guo, Morin, Sinitskii, C. Stains, M. Stains, Zhang</p>
 <p class="faculty-list"><span class="faculty-list-bold">Professors of Practice:</span> Kautz, Malina</p>
@@ -32,36 +32,33 @@
 <p class="content-box-h-1">MAJOR REQUIREMENTS</p>
 <p class="title-1">Specific Major Requirements</p>
 <p class="title-2">Bachelor of Science in Chemistry – Required Program of Study</p>
-<p class="requirement-sec-1">Chemistry 46</p>
+<p class="requirement-sec-1">Chemistry 45</p>
 <p class="requirement-sec-2">CHEM 101 Career Opportunities in Chemistry 1</p>
-<p class="requirement-sec-2">Fundamental Chemistry &amp; Quantitative Analysis 12</p>
+<p class="requirement-sec-2">Fundamental Chemistry &amp; Quantitative Analysis 11</p>
 <p class="requirement-sec-3">CHEM 113 Fundamental Chemistry I 4</p>
-<p class="requirement-sec-3">CHEM 114 Fundamental Chemistry II 4</p>
+<p class="requirement-sec-3">CHEM 114 Fundamental Chemistry II 3</p>
 <p class="requirement-sec-3">CHEM 221 Elementary Quantitative Analysis 4</p>
 <p class="requirement-sec-2">Organic Chemistry 10</p>
 <p class="requirement-sec-3">CHEM 261 Organic Chemistry 3</p>
 <p class="requirement-sec-3">CHEM 262 Organic Chemistry 3</p>
 <p class="requirement-sec-3">CHEM 263 Organic Chemistry Lab 2</p>
 <p class="requirement-sec-3">CHEM 264 Organic Chemistry Lab 2</p>
-<p class="requirement-sec-2">Biochemistry 5</p>
-<p class="requirement-sec-3">CHEM 431 Structure &amp; Metabolism 3</p>
-<p class="requirement-sec-3">CHEM 433 Biochemistry Lab 2</p>
-
+<p class="requirement-sec-2">Biochemistry or Chemical Biology 5</p>
+<p class="requirement-sec-3">CHEM 431 &amp; CHEM 433 Structure &amp; Metabolism &amp; Biological Lab (5 cr) or CHEM 435 &amp; CHEM 433 Chemical Biology &amp; Biological Lab (5 cr)</p>
 <p class="requirement-sec-2">Physical Chemistry 11</p>
 <p class="requirement-sec-3">CHEM 481 Physical Chemistry I 4</p>
 <p class="requirement-sec-3">CHEM 482 Physical Chemistry II 4</p>
 <p class="requirement-sec-3">CHEM 484 Physical Chemical Measurements 3</p>
 <p class="requirement-sec-2">Undergraduate Research 2</p>
 <p class="requirement-sec-3">CHEM 399 Undergraduate Research in Chemistry <span class="requirement-ital">(at least 2 cr)</span> 2</p>
-
 <p class="requirement-sec-2"><span class="requirement-ital">Select one of the following combinations</span>: 5</p>
 <p class="requirement-sec-2">CHEM 421 &amp; CHEM 423 Analytical Chemistry &amp; Lab (5 cr)</p>
-<p class="requirement-sec-2">CHEM 441 &amp; CHEM 443 Inorganic Chemistry &amp; Lab  (5 cr)</p>
-<p class="requirement-sec-1">Math 13 </p>
+<p class="requirement-sec-2">CHEM 441 &amp; CHEM 443 Inorganic Chemistry &amp; Lab (5 cr)</p>
+<p class="requirement-sec-1">Math 13</p>
 <p class="requirement-sec-2">MATH 106 Calculus I 5</p>
 <p class="requirement-sec-2">MATH 107 Calculus II 4</p>
 <p class="requirement-sec-2">MATH 208 Calculus III 4</p>
-<p class="requirement-sec-1">Physics 8 </p>
+<p class="requirement-sec-1">Physics 8</p>
 <p class="requirement-sec-2">PHYS 211 General Physics I 4</p>
 <p class="requirement-sec-2">PHYS 212 General Physics II 4</p>
 <p class="requirement-sec-3 requirement-ital">(with recommendations of PHYS 213 &amp; PHYS 222)</p>
@@ -72,7 +69,6 @@
 <p class="requirement-sec-3">CHEM 109 General Chemistry I 4</p>
 <p class="requirement-sec-3">CHEM 110 General Chemistry II 4</p>
 <p class="requirement-sec-3">CHEM 221 Elementary Quantitative Analysis 4</p>
-
 <p class="requirement-sec-2">Organic Chemistry 8</p>
 <p class="requirement-sec-3">CHEM 251 Organic Chemistry I 3</p>
 <p class="requirement-sec-3">CHEM 252 Organic Chemistry II 3</p>
@@ -100,7 +96,9 @@
 <p class="content-box-h-1">ADDITIONAL MAJOR REQUIREMENTS</p>
 <p class="title-1">Grade Rules</p>
 <p class="title-2">Pass/No Pass Limits</p>
-<p class="basic-text">Students majoring in chemistry may not take chemistry courses Pass/No Pass except for CHEM 396 and/or CHEM 399. Chemistry majors may take up to 6 hours in minor courses Pass/No Pass subject to approval of the department granting the minor.</p>
+<p class="title-2">Students majoring in chemistry may not take chemistry courses Pass/No Pass except for CHEM 396 and/or CHEM 399.</p>
+
+
 <p class="content-box-h-1">REQUIREMENTS FOR MINOR OFFERED BY DEPARTMENT</p>
 <p class="title-2">Plan A Minor</p>
 <p class="header-paragraph"><span class="header-paragraph-title">The Plan A chemistry minor is for students with only one minor. The program of study is:</span> completion of a freshman chemistry sequence (CHEM 109, CHEM 110, and CHEM 221 or CHEM 113, CHEM 114, and CHEM 221) plus an additional 12 hours of chemistry excluding CHEM 131, CHEM 195, CHEM 396, and CHEM 399.</p>

--- a/data/2016/majors/Chemistry.xhtml
+++ b/data/2016/majors/Chemistry.xhtml
@@ -95,8 +95,9 @@
 <p class="basic-text">Results of participation in these assessment activities will in no way affect a students GPA or graduation.</p>
 <p class="content-box-h-1">ADDITIONAL MAJOR REQUIREMENTS</p>
 <p class="title-1">Grade Rules</p>
+<p class="title-1">The grades of all Chemistry courses required for the major must be C or better. The grades of all Math and Physics courses required for the major must be C or better.</p>
 <p class="title-2">Pass/No Pass Limits</p>
-<p class="title-2">Students majoring in chemistry may not take chemistry courses Pass/No Pass except for CHEM 396 and/or CHEM 399.</p>
+<p class="title-2">Pass/No Pass courses are not allowed in the major or minor except for CHEM 101, CHEM 396, and/or CHEM 399.</p>
 
 
 <p class="content-box-h-1">REQUIREMENTS FOR MINOR OFFERED BY DEPARTMENT</p>

--- a/data/2016/majors/Chemistry.xhtml
+++ b/data/2016/majors/Chemistry.xhtml
@@ -95,10 +95,10 @@
 <p class="basic-text">Results of participation in these assessment activities will in no way affect a students GPA or graduation.</p>
 <p class="content-box-h-1">ADDITIONAL MAJOR REQUIREMENTS</p>
 <p class="title-1">Grade Rules</p>
-<p class="title-1">The grades of all Chemistry courses required for the major must be C or better. The grades of all Math and Physics courses required for the major must be C or better.</p>
+<p class="title-2">Grades</p>
+<p class="basic-text">The grades of all Chemistry courses required for the major must be C or better. The grades of all Math and Physics courses required for the major must be C or better.</p>
 <p class="title-2">Pass/No Pass Limits</p>
-<p class="title-2">Pass/No Pass courses are not allowed in the major or minor except for CHEM 101, CHEM 396, and/or CHEM 399.</p>
-
+<p class="basic-text">Pass/No Pass courses are not allowed in the major or minor except for CHEM 101, CHEM 396, and/or CHEM 399.</p>
 
 <p class="content-box-h-1">REQUIREMENTS FOR MINOR OFFERED BY DEPARTMENT</p>
 <p class="title-2">Plan A Minor</p>


### PR DESCRIPTION
Updating bulletin section.

1. Correct a credit hour error for CHEM 114, the total number of subsection credit hours and the total number of program credit hours for the BS program.

2. Students in the BS program can take either the Biochemistry sequence (CHEM 431 and Chem 433) or the Chemical Biology sequence (CHEM 435 and CHEM 433).

3. Clarity of the P/NP and C or better rule in the minors as well as math and physics courses.
