### PR TITLE
Finalize Request #10478

### DIFF
--- a/data/2016/majors/Mathematics.xhtml
+++ b/data/2016/majors/Mathematics.xhtml
@@ -19,20 +19,22 @@
                 <p class="quick-points"><span class="quick-point-bold">MINOR AVAILABLE:</span> Yes</p>
                 <p class="quick-points"><span class="quick-point-bold">ADVISOR:</span> Tom Marley and Lori Mueller</p>
 <p class="content-box-h-1">DESCRIPTION</p>
-<p class="faculty-list"><span class="faculty-list-bold">Chair: Judy Walker,</span> 206 Avery Hall</p>
-<p class="faculty-list"><span class="faculty-list-bold">Vice Chair:</span> Allan Donsig</p>
-<p class="faculty-list"><span class="faculty-list-bold">Professors:</span> Avalos, Avramov, Deng, Harbourne, Hermiller, Ledder, Lewis, Marley, Peterson, Pitts, Radcliffe, Rammaha, Rebarber, J. Walker, M. Walker</p>
-<p class="faculty-list"><span class="faculty-list-bold">Associate Professors:</span> Brittenham, Cohn, Donsig, Foss, Kelley, Radu, Tenhumberg, Toundykov</p>
-<p class="faculty-list"><span class="faculty-list-bold">Assistant Professors:</span> Jin, Lai, Larios, Lee, Seceleanu, Zhang, Zupan</p>
-<p class="faculty-list"><span class="faculty-list-bold">Assistant Professor of Practice:</span> Wakefield</p>
+<p class="faculty-list">Chair: Judy Walker, 206 Avery Hall</p>
+<p class="faculty-list">Vice Chair: Allan Donsig</p>
+<p class="faculty-list">Professors: Avalos, Avramov, Brittenham, Deng, Donsig, Harbourne, Hermiller, Ledder, Lewis, Marley, Peterson, Pitts, Radcliffe, Rammaha, Rebarber, J. Walker, M. Walker</p>
+<p class="faculty-list">Associate Professors:  Cohn, Foss, Kelley, Radu, Tenhumberg, Toundykov</p>
+<p class="faculty-list">Assistant Professors: Du, Jin, T.Lai, Y. Lai, Larios, Lee, Perez, Seceleanu, Zupan</p>
+<p class="faculty-list">Research Associate Professor: Smith</p>
+<p class="faculty-list">Research Assistant Professor: Homp</p>
+<p class="faculty-list">Assistant Professor of Practice: Wakefield</p>
 <p class="basic-text">A strong mathematics background is essential to an increasing variety of careers. The Department of Mathematics encourages students to select a coherent body of courses in mathematics and in other disciplines that are consistent with their academic and career goals.</p>
 <p class="basic-text">The Department of Mathematics offers four options for the major in mathematics. Each student majoring in mathematics should select an option that meets their academic and career needs by completing a Program Declaration form in consultation with the department's chief undergraduate advisor. Ideally, this should be done prior to completing two mathematics courses beyond the calculus sequence. As appropriate, students can change their Program Declaration to select a different option or modify the program of study subject to the approval of the chief undergraduate advisor.</p>
-<p class="basic-text"><span class="basic-text-bold">NOTE:</span> Students with previous credit in any calculus course may not register for or earn credit in MATH 100A, MATH 101, MATH 102, MATH 103, or MATH 104, without first receiving special written permission from the chief undergraduate advisor.</p>
-<p class="header-paragraph"><span class="header-paragraph-title">Graduate Work. </span>The advanced degrees of master of arts, master of science, master of arts (or science) for teachers, and doctor of philosophy are offered by the Department of Mathematics. For details of these programs, see the Graduate Studies Bulletin.</p>
+<p class="basic-text">NOTE: Students with previous credit in any calculus course may not register for or earn credit in MATH 100A, MATH 101, MATH 102, MATH 103, or MATH 104, without first receiving special written permission from the chief undergraduate advisor.</p>
+<p class="header-paragraph">Graduate Work. The advanced degrees of master of arts, master of science, master of arts (or science) for teachers, and doctor of philosophy are offered by the Department of Mathematics. For details of these programs, see the Graduate Studies Bulletin.</p>
 <p class="content-box-h-1">MAJOR REQUIREMENTS</p>
 <p class="title-1">Bachelor of Arts</p>
 <p class="basic-text">The BA degree is ideal for the student who wants to combine a mathematics major with another major or several minors in the humanities or the social sciences or for the student dual matriculating with another college.</p>
-<p class="title-2">Core Requirements</p>
+<p class="title-2">Core Requirements:</p>
 <ul>
 <li>A complete calculus sequence: MATH 106, MATH 107, MATH 208 <span class="basic-text-bold">or</span> MATH 108H, MATH 109H, <span class="basic-text-bold">or</span> equivalent</li>
 <li>21 hrs (seven courses) selected from the advanced mathematics course list.</li>
@@ -48,7 +50,7 @@
 <p class="header-paragraph"><span class="header-paragraph-title">NOTE:</span> Students may substitute a more advanced course in the same area for a required mathematics course. Interested students should visit with the chief undergraduate advisor for more information about this option.</p>
 <p class="header-paragraph"><span class="header-paragraph-title">Program Assessment.</span> In order to assist the department in evaluating its programs, all majors should plan to participate in an exit interview during their last semester before graduation. Please make arrangements with the chief undergraduate advisor.</p>
 <p class="title-1">Bachelor of Science</p>
-<p class="title-2">Core Requirements</p>
+<p class="title-2">Core Requirements:</p>
 <ul>
 <li>A complete calculus sequence: MATH 106, MATH 107, MATH 208 <span class="basic-text-bold">or</span> MATH 108H, MATH 109H, <span class="basic-text-bold">or</span> equivalent</li>
 <li>24 hrs (eight courses) selected from the advanced mathematics course list</li>
@@ -70,10 +72,10 @@
 <p class="header-paragraph">–Any Plan A minor or an approved 18-hour concentration outside of mathematics.</p>
 <p class="header-paragraph"><span class="header-paragraph-title">NOTE:</span> One 400-level course in the area of the concentration may be substituted for one of the required two additional advanced mathematics courses, provided the course makes significant use of advanced mathematics. The chief undergraduate advisor must approve the substitution.</p>
 <p class="title-2">Option E (Education)</p>
-<p class="basic-text">This option is ideal for students interested in teaching mathematics at the secondary level. Specific requirements above calculus are as follows:</p>
+<p class="basic-text">This option is ideal for students planning to pursue endorsement and certification to teach mathematics at the secondary level through an undergraduate degree in the College of Education and Human Sciences or through a graduate program. Specific requirements above calculus are as follows:</p>
 <ul>
 <li>MATH 310, MATH 314, MATH 325, MATH 350, MATH 380/STAT 380, MATH 405, MATH 407, MATH 408</li>
-<li>An education minor or an approved 18-hour concentration in education</li>
+<li>An education minor or major, or an approved 18-hour concentration in education</li>
 </ul>
 <p class="title-2">Option R (Research Experience)</p>
 <p class="basic-text">This option is recommended for students interested in independent work and for students planning to pursue graduate work in mathematics. Specific requirements above calculus are as follows:</p>
@@ -83,7 +85,7 @@
 <li>At least three advanced mathematics courses at the 400 level</li>
 <li>One more advanced mathematics course</li>
 </ul>
-<p class="header-paragraph">– An approved undergraduate research experience. A variety of options exist for meeting this requirement. They include 1) research experiences such as an REU or UCARE that leads to a project paper, 2) a senior honors thesis or a thesis approved for graduation with distinction, or 3) a grade of P in MATH 496 Undergraduate Research Seminar (this course would be in addition to the advanced mathematics courses requirement above). To satisfy this requirement, students must file with the chief undergraduate advisor a) a Research Experience contract that is approved by the chief undergraduate advisor and b) the thesis, research papers, or projects as required by the contract. Visit with the chief undergraduate advisor for more information.</p>
+<p class="header-paragraph">– An approved undergraduate research experience. A variety of options exist for meeting this requirement. They include 1) research experiences such as an REU or UCARE that leads to a project paper, or 2) a senior honors thesis or a thesis approved for graduation with distinction. To satisfy this requirement, students must file with the chief undergraduate advisor a) a Research Experience contract that is approved by the chief undergraduate advisor and b) the thesis, research papers, or projects as required by the contract. Visit with the chief undergraduate advisor for more information.</p>
 <p class="title-2">Option S (Statistics)</p>
 <p class="basic-text">This option is recommended for students interested in a mathematics major and a strong body of course work in statistics. Specific requirements above calculus are as follows:</p>
 <p class="header-paragraph">– The eight required mathematics courses must be distributed as follows:</p>

--- a/data/2016/majors/Mathematics.xhtml
+++ b/data/2016/majors/Mathematics.xhtml
@@ -19,22 +19,22 @@
                 <p class="quick-points"><span class="quick-point-bold">MINOR AVAILABLE:</span> Yes</p>
                 <p class="quick-points"><span class="quick-point-bold">ADVISOR:</span> Tom Marley and Lori Mueller</p>
 <p class="content-box-h-1">DESCRIPTION</p>
-<p class="faculty-list">Chair: Judy Walker, 206 Avery Hall</p>
-<p class="faculty-list">Vice Chair: Allan Donsig</p>
-<p class="faculty-list">Professors: Avalos, Avramov, Brittenham, Deng, Donsig, Harbourne, Hermiller, Ledder, Lewis, Marley, Peterson, Pitts, Radcliffe, Rammaha, Rebarber, J. Walker, M. Walker</p>
-<p class="faculty-list">Associate Professors:  Cohn, Foss, Kelley, Radu, Tenhumberg, Toundykov</p>
-<p class="faculty-list">Assistant Professors: Du, Jin, T.Lai, Y. Lai, Larios, Lee, Perez, Seceleanu, Zupan</p>
-<p class="faculty-list">Research Associate Professor: Smith</p>
-<p class="faculty-list">Research Assistant Professor: Homp</p>
-<p class="faculty-list">Assistant Professor of Practice: Wakefield</p>
+<p class="faculty-list"><span class="faculty-list-bold">Chair: Judy Walker</span>, 206 Avery Hall</p>
+<p class="faculty-list"><span class="faculty-list-bold">Vice Chair:</span> Allan Donsig</p>
+<p class="faculty-list"><span class="faculty-list-bold">Professors:</span> Avalos, Avramov, Brittenham, Deng, Donsig, Harbourne, Hermiller, Ledder, Lewis, Marley, Peterson, Pitts, Radcliffe, Rammaha, Rebarber, J. Walker, M. Walker</p>
+<p class="faculty-list"><span class="faculty-list-bold">Associate Professors:</span>  Cohn, Foss, Kelley, Radu, Tenhumberg, Toundykov</p>
+<p class="faculty-list"><span class="faculty-list-bold">Assistant Professors:</span> Du, Jin, T.Lai, Y. Lai, Larios, Lee, Perez, Seceleanu, Zupan</p>
+<p class="faculty-list"><span class="faculty-list-bold">Research Associate Professor:</span> Smith</p>
+<p class="faculty-list"><span class="faculty-list-bold">Research Assistant Professor:</span> Homp</p>
+<p class="faculty-list"><span class="faculty-list-bold">Assistant Professor of Practice:</span> Wakefield</p>
 <p class="basic-text">A strong mathematics background is essential to an increasing variety of careers. The Department of Mathematics encourages students to select a coherent body of courses in mathematics and in other disciplines that are consistent with their academic and career goals.</p>
 <p class="basic-text">The Department of Mathematics offers four options for the major in mathematics. Each student majoring in mathematics should select an option that meets their academic and career needs by completing a Program Declaration form in consultation with the department's chief undergraduate advisor. Ideally, this should be done prior to completing two mathematics courses beyond the calculus sequence. As appropriate, students can change their Program Declaration to select a different option or modify the program of study subject to the approval of the chief undergraduate advisor.</p>
-<p class="basic-text">NOTE: Students with previous credit in any calculus course may not register for or earn credit in MATH 100A, MATH 101, MATH 102, MATH 103, or MATH 104, without first receiving special written permission from the chief undergraduate advisor.</p>
-<p class="header-paragraph">Graduate Work. The advanced degrees of master of arts, master of science, master of arts (or science) for teachers, and doctor of philosophy are offered by the Department of Mathematics. For details of these programs, see the Graduate Studies Bulletin.</p>
+<p class="basic-text"><span class="basic-text-bold">NOTE:</span> Students with previous credit in any calculus course may not register for or earn credit in MATH 100A, MATH 101, MATH 102, MATH 103, or MATH 104, without first receiving special written permission from the chief undergraduate advisor.</p>
+<p class="header-paragraph"><span class="header-paragraph-title">Graduate Work.</span> The advanced degrees of master of arts, master of science, master of arts (or science) for teachers, and doctor of philosophy are offered by the Department of Mathematics. For details of these programs, see the Graduate Studies Bulletin.</p>
 <p class="content-box-h-1">MAJOR REQUIREMENTS</p>
 <p class="title-1">Bachelor of Arts</p>
 <p class="basic-text">The BA degree is ideal for the student who wants to combine a mathematics major with another major or several minors in the humanities or the social sciences or for the student dual matriculating with another college.</p>
-<p class="title-2">Core Requirements:</p>
+<p class="title-2">Core Requirements</p>
 <ul>
 <li>A complete calculus sequence: MATH 106, MATH 107, MATH 208 <span class="basic-text-bold">or</span> MATH 108H, MATH 109H, <span class="basic-text-bold">or</span> equivalent</li>
 <li>21 hrs (seven courses) selected from the advanced mathematics course list.</li>
@@ -50,7 +50,7 @@
 <p class="header-paragraph"><span class="header-paragraph-title">NOTE:</span> Students may substitute a more advanced course in the same area for a required mathematics course. Interested students should visit with the chief undergraduate advisor for more information about this option.</p>
 <p class="header-paragraph"><span class="header-paragraph-title">Program Assessment.</span> In order to assist the department in evaluating its programs, all majors should plan to participate in an exit interview during their last semester before graduation. Please make arrangements with the chief undergraduate advisor.</p>
 <p class="title-1">Bachelor of Science</p>
-<p class="title-2">Core Requirements:</p>
+<p class="title-2">Core Requirements</p>
 <ul>
 <li>A complete calculus sequence: MATH 106, MATH 107, MATH 208 <span class="basic-text-bold">or</span> MATH 108H, MATH 109H, <span class="basic-text-bold">or</span> equivalent</li>
 <li>24 hrs (eight courses) selected from the advanced mathematics course list</li>
@@ -69,7 +69,7 @@
 <li>At least two more advanced mathematics courses at the 400 level</li>
 <li>Two additional advanced mathematics courses</li>
 </ul>
-<p class="header-paragraph">–Any Plan A minor or an approved 18-hour concentration outside of mathematics.</p>
+<p class="header-paragraph">– Any Plan A minor or an approved 18-hour concentration outside of mathematics.</p>
 <p class="header-paragraph"><span class="header-paragraph-title">NOTE:</span> One 400-level course in the area of the concentration may be substituted for one of the required two additional advanced mathematics courses, provided the course makes significant use of advanced mathematics. The chief undergraduate advisor must approve the substitution.</p>
 <p class="title-2">Option E (Education)</p>
 <p class="basic-text">This option is ideal for students planning to pursue endorsement and certification to teach mathematics at the secondary level through an undergraduate degree in the College of Education and Human Sciences or through a graduate program. Specific requirements above calculus are as follows:</p>
@@ -96,7 +96,7 @@
 <li>Two more advanced mathematics courses</li>
 </ul>
 <p class="header-paragraph">– 9 hrs of statistics numbered 300 or above in addition to MATH 380/STAT 380</p>
-<p class="list-indent"><span class="faculty-list-bold">NOTE:</span> For this option, one 400-level statistics course may be substituted for one of the required two additional advanced mathematics courses.</p>
+<p class="header-paragraph"><span class="header-paragraph-title">NOTE:</span> For this option, one 400-level statistics course may be substituted for one of the required two additional advanced mathematics courses.</p>
 <p class="header-paragraph"><span class="header-paragraph-title">NOTE:</span> Under any option, students may substitute a more advanced course in the same area for a required mathematics course. Interested students should visit with the chief undergraduate advisor for more information about this option.</p>
 <p class="content-box-h-1">ADDITIONAL MAJOR REQUIREMENTS</p>
 <p class="title-1">Prerequisite Requirements/Rules</p>


### PR DESCRIPTION
These are mostly "bookkeeping" changes, such as updating faculty lists and the reference to Math 496, which doesn't exist anymore.   The one substantive change is in the description of Option E.  This is due to the fact that CEHS will no longer certify for secondary teaching students that are not matriculating in their college.