### PR TITLE
Finalize Request #11162

### DIFF
--- a/data/2017/majors/Ethnic Studies.xhtml
+++ b/data/2017/majors/Ethnic Studies.xhtml
@@ -171,7 +171,7 @@
 <p class="requirement-sec-2">ETHN 272 Modern Latin America (HIST 272/LAMS 272) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 277 Latin American Politics (LAMS 277/POLS 277) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 285 Africa Since 1800 (HIST 285) (3 cr)</p>
-<p class="requirement-sec-2">ETHN 310 Psychology of Immingration (PSYCH 310) (3 cr)</p>
+<p class="requirement-sec-2">ETHN 310 Psychology of Immigration (PSYCH 310) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 330 Multicultural Education (TEAC 330) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 342 History of Plains Indians (HIST 342) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 344 Ethnicity &amp; Film (ENGL 344) (3 cr)</p>

--- a/data/2017/majors/Ethnic Studies.xhtml
+++ b/data/2017/majors/Ethnic Studies.xhtml
@@ -55,7 +55,7 @@
 <p class="requirement-sec-3">ETHN 217 Sociology of Race &amp; Ethnicity (SOCI 217) (3 cr)</p>
 <p class="requirement-sec-3">ETHN 310 Psychology of Immigration (PSYC 310) (3 cr)</p>
 <p class="requirement-sec-3">ETHN 330 Multicultural Education (TEAC 330) (3 cr)</p>
-<p class="requirement-sec-3">ETHN 340 American Legal History</p>
+<p class="requirement-sec-3">ETHN 340 American Legal History (HIST 340) (3 cr)</p>
 <p class="requirement-sec-3">ETHN 341 American West to 1900 (HIST 351) (3 cr)</p>
 <p class="requirement-sec-3">ETHN 344 Ethnicity &amp; Film (ENGL 344) (3 cr)</p>
 <p class="requirement-sec-3">ETHN 425 Psychology of Racism (PSYC 425) (3 cr)</p>

--- a/data/2017/majors/Ethnic Studies.xhtml
+++ b/data/2017/majors/Ethnic Studies.xhtml
@@ -146,7 +146,7 @@
 <p class="title-1">Minor Requirements</p>
 <p class="basic-text">Students must also complete a Plan A minor from a discipline other than Ethnic Studies or one of its component programs.</p>
 <p class="content-box-h-1">REQUIREMENTS FOR MINOR OFFERED BY DEPARTMENT</p>
-<p class="requirement-sec-1">18 hours from the following courses <span class="requirement-ital">(other courses may be used with the approval of the faculty advisor)</span>:</p>
+<p class="requirement-sec-1">18 hours from the following courses with a minimum of 6 hours in courses numbered 300 and above <span class="requirement-ital">(other courses may be used with the approval of the faculty advisor)</span>:</p>
 <p class="requirement-sec-2">ETHN 100 Freshman Seminar: The Minority Experience (3 cr)</p>
 <p class="requirement-sec-2">ETHN 113 History of Hip Hop (HIST 113) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 150 African Culture &amp; Civilization (HIST 150) (3 cr)</p>

--- a/data/2017/majors/Ethnic Studies.xhtml
+++ b/data/2017/majors/Ethnic Studies.xhtml
@@ -2,11 +2,11 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <title>Ethnic Studies 16-17.xhtml</title>
+        <title>Ethnic Studies 17-18.xhtml</title>
         <link href="template.css" rel="stylesheet" type="text/css" />
     </head>
     <body>
-        <div id="ethnic-studies-16-17">
+        <div id="ethnic-studies-17-18">
             <div class="generated-style">
                 <p class="major-name">Ethnic Studies</p>
             </div>
@@ -21,9 +21,9 @@
 <p class="content-box-h-1">DESCRIPTION</p>
 <p class="faculty-list"><span class="faculty-list-bold">Director: Joy Castro</span> (English), 303 Seaton Hall</p>
 <p class="faculty-list"><span class="faculty-list-bold">Associate Director:</span> James Garza (History)</p>
-<p class="faculty-list"><span class="faculty-list-bold">Faculty: </span>Castro, Dreher, Gannon, Montes, Rutledge (English); Ari, Curry, Garza, J. Jones, P. Jones, Smith (history); Gonzáles (modern languages and literatures); Kang, Wals (political science); Willis-Esqueda (psychology); Dance (sociology)</p>
+<p class="faculty-list"><span class="faculty-list-bold">Faculty: </span>Castro, Dreher, Gannon, Montes, Rutledge (English); Ari, Curry, Garza, Huettl, J. Jones, P. Jones, Smith (history); Gonzáles, Robyn, Rosa (modern languages and literatures); Kang, Wals (political science); Andrews, Willis-Esqueda (psychology); Dance (sociology)</p>
 <p class="basic-text">Ethnic Studies involves the exploration and examination of factors that bear on the lives and experiences, both past and present, of ethnically diverse peoples. The Institute for Ethnic Studies is interdisciplinary and intercollegiate, and focuses on the experiences of individuals and groups who are of African-American, Latino/a, or Native origin or descent both in the United States and elsewhere.</p>
-<p class="basic-text">Within the Institute, a major and a minor can be taken in Ethnic Studies (described below). Program-specific minors are also available in African Studies, African-American Studies (see listing for African-American and African Studies), U.S. Latina/Latino Studies (see Latino and Latin American Studies), and Native American Studies (see separate bulletin listing); both a major and a minor are available in Latin American Studies (see Latino and Latin American Studies).</p>
+<p class="basic-text">Within the Institute, a major and a minor can be taken in Ethnic Studies (described below). Program-specific minors are also available in African Studies, African-American Studies (see listing for African and African American Studies), U.S. Latina/Latino Studies (see Latino and Latin American Studies), and Native American Studies (see separate bulletin listing); both a major and a minor are available in Latin American Studies (see Latino and Latin American Studies).</p>
 <p class="content-box-h-1">MAJOR REQUIREMENTS</p>
 <p class="title-1">Specific Major Requirements</p>
 <p class="basic-text">All majors must take 33 credit hours, to include 15 credit hours from Groups A, B, and C (as described below) plus one of the following:</p>
@@ -55,6 +55,7 @@
 <p class="requirement-sec-3">ETHN 217 Sociology of Race &amp; Ethnicity (SOCI 217) (3 cr)</p>
 <p class="requirement-sec-3">ETHN 310 Psychology of Immigration (PSYC 310) (3 cr)</p>
 <p class="requirement-sec-3">ETHN 330 Multicultural Education (TEAC 330) (3 cr)</p>
+<p class="requirement-sec-3">ETHN 340 American Legal History</p>
 <p class="requirement-sec-3">ETHN 341 American West to 1900 (HIST 351) (3 cr)</p>
 <p class="requirement-sec-3">ETHN 344 Ethnicity &amp; Film (ENGL 344) (3 cr)</p>
 <p class="requirement-sec-3">ETHN 425 Psychology of Racism (PSYC 425) (3 cr)</p>
@@ -63,7 +64,7 @@
 <p class="requirement-sec-3">ETHN 454 Physical Health Disparities (SOCI 454) (3 cr)</p>
 <p class="requirement-sec-3">ETHN 481 Minority Groups (SOCI 481) (3 cr)</p>
 <p class="requirement-sec-3">POLS 260 Problems in International Relations (3 cr)</p>
-<p class="title-3">D. African-American and African Studies</p>
+<p class="title-3">D. African and African American Studies</p>
 <p class="requirement-sec-3">ETHN 113 History of Hip Hop (HIST 113) (3 cr)</p>
 <p class="requirement-sec-3">ETHN 150 African Culture &amp; Civilization (HIST 150) (3 cr)</p>
 <p class="requirement-sec-3">ETHN 200 Introduction to African-American Studies (3 cr)</p>
@@ -76,7 +77,7 @@
 <p class="requirement-sec-3">ETHN 247 African-American History: After 1877 (HIST 247) (3 cr)</p>
 <p class="requirement-sec-3">ETHN 285 Africa Since 1800 (HIST 285) (3 cr)</p>
 <p class="requirement-sec-3">ETHN 344B Black Women Authors (ENGL 344B/WMNS 344B) (3 cr)</p>
-<p class="requirement-sec-3">ETHN 344D African-Caribbean Literature (ENGL 344D) (3 cr)</p>
+<p class="requirement-sec-3">ETHN 344D Caribbean Literature (ENGL 344D) (3 cr)</p>
 <p class="requirement-sec-3">ETHN 347 African Architecture (ARCH 347/AHIS 366) (3 cr)</p>
 <p class="requirement-sec-3">ETHN 356 African-American Women's History (HIST 356/WMNS 356) (3 cr)</p>
 <p class="requirement-sec-3">ETHN 362 Peoples &amp; Cultures of Africa (ANTH 362) (3 cr)</p>
@@ -170,11 +171,12 @@
 <p class="requirement-sec-2">ETHN 272 Modern Latin America (HIST 272/LAMS 272) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 277 Latin American Politics (LAMS 277/POLS 277) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 285 Africa Since 1800 (HIST 285) (3 cr)</p>
+<p class="requirement-sec-2">ETHN 310 Psychology of Immingrations (PSYCH 310) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 330 Multicultural Education (TEAC 330) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 342 History of Plains Indians (HIST 342) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 344 Ethnicity &amp; Film (ENGL 344) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 344B Black Women Authors (ENGL 344B/WMNS 344B) (3 cr)</p>
-<p class="requirement-sec-2">ETHN 344D African-Caribbean Literature (ENGL 344D) (3 cr)</p>
+<p class="requirement-sec-2">ETHN 344D Caribbean Literature (ENGL 344D) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 345D Chicana and/or Chicano Literature (ENGL 345D) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 345N Native American Women Writers (ENGL 345N/WMNS 345N) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 346 Cuban-American Literature (ENGL 346) (3 cr)</p>
@@ -192,6 +194,7 @@
 <p class="requirement-sec-2">ETHN 375 Conflict &amp; Development in Africa (POLS 375) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 385 African Liberation in the African Diaspora (HIST 385) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 400 Senior Seminar (3 cr)</p>
+<p class="requirement-sec-2">ETHN 425 Psychology of Racism (PSYCH 425) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 445 Ethnic Literature (ENGL 445) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 445B Topics in African American Literature (ENGL 445B) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 445K Topics in African Literature (ENGL 445K) (3 cr)</p>

--- a/data/2017/majors/Ethnic Studies.xhtml
+++ b/data/2017/majors/Ethnic Studies.xhtml
@@ -23,7 +23,7 @@
 <p class="faculty-list"><span class="faculty-list-bold">Associate Director:</span> James Garza (History)</p>
 <p class="faculty-list"><span class="faculty-list-bold">Faculty: </span>Castro, Dreher, Gannon, Montes, Rutledge (English); Ari, Curry, Garza, Huettl, J. Jones, P. Jones, Smith (history); Gonzáles, Robyn, Rosa (modern languages and literatures); Kang, Wals (political science); Andrews, Willis-Esqueda (psychology); Dance (sociology)</p>
 <p class="basic-text">Ethnic Studies involves the exploration and examination of factors that bear on the lives and experiences, both past and present, of ethnically diverse peoples. The Institute for Ethnic Studies is interdisciplinary and intercollegiate, and focuses on the experiences of individuals and groups who are of African-American, Latino/a, or Native origin or descent both in the United States and elsewhere.</p>
-<p class="basic-text">Within the Institute, a major and a minor can be taken in Ethnic Studies (described below). Program-specific minors are also available in African Studies, African-American Studies (see listing for African and African American Studies), U.S. Latina/Latino Studies (see Latino and Latin American Studies), and Native American Studies (see separate bulletin listing); both a major and a minor are available in Latin American Studies (see Latino and Latin American Studies).</p>
+<p class="basic-text">Within the Institute, a major and a minor can be taken in Ethnic Studies (described below). Program-specific minors are also available in African Studies, African-American Studies (see listing for African and African-American Studies), U.S. Latina/Latino Studies (see Latino and Latin American Studies), and Native American Studies (see separate bulletin listing); both a major and a minor are available in Latin American Studies (see Latino and Latin American Studies).</p>
 <p class="content-box-h-1">MAJOR REQUIREMENTS</p>
 <p class="title-1">Specific Major Requirements</p>
 <p class="basic-text">All majors must take 33 credit hours, to include 15 credit hours from Groups A, B, and C (as described below) plus one of the following:</p>
@@ -64,7 +64,7 @@
 <p class="requirement-sec-3">ETHN 454 Physical Health Disparities (SOCI 454) (3 cr)</p>
 <p class="requirement-sec-3">ETHN 481 Minority Groups (SOCI 481) (3 cr)</p>
 <p class="requirement-sec-3">POLS 260 Problems in International Relations (3 cr)</p>
-<p class="title-3">D. African and African American Studies</p>
+<p class="title-3">D. African and African-American Studies</p>
 <p class="requirement-sec-3">ETHN 113 History of Hip Hop (HIST 113) (3 cr)</p>
 <p class="requirement-sec-3">ETHN 150 African Culture &amp; Civilization (HIST 150) (3 cr)</p>
 <p class="requirement-sec-3">ETHN 200 Introduction to African-American Studies (3 cr)</p>
@@ -81,10 +81,10 @@
 <p class="requirement-sec-3">ETHN 347 African Architecture (ARCH 347/AHIS 366) (3 cr)</p>
 <p class="requirement-sec-3">ETHN 356 African-American Women's History (HIST 356/WMNS 356) (3 cr)</p>
 <p class="requirement-sec-3">ETHN 362 Peoples &amp; Cultures of Africa (ANTH 362) (3 cr)</p>
-<p class="requirement-sec-3">ETHN 366 African Americans &amp; the Politics of Race: From the New Deal to the New Right (HIST 366) (3 cr)</p>
+<p class="requirement-sec-3">ETHN 366 African-Americans &amp; the Politics of Race: From the New Deal to the New Right (HIST 366) (3 cr)</p>
 <p class="requirement-sec-3">ETHN 375 Conflict &amp; Development in Africa (POLS 375) (3 cr)</p>
 <p class="requirement-sec-3">ETHN 385 African Liberation in the African Diaspora (HIST 385) (3 cr)</p>
-<p class="requirement-sec-3">ETHN 445B Topics in African American Literature (ENGL 445B) (3 cr)</p>
+<p class="requirement-sec-3">ETHN 445B Topics in African-American Literature (ENGL 445B) (3 cr)</p>
 <p class="requirement-sec-3">ETHN 445K Topics in African Literature (ENGL 445K) (3 cr)</p>
 <p class="requirement-sec-3">ETHN 459 Women &amp; Gender in African Societies (HIST 459/WMNS 459) (3 cr)</p>
 <p class="requirement-sec-3">ETHN 460 The Civil Rights Movement (HIST 460) (3 cr)</p>
@@ -186,7 +186,7 @@
 <p class="requirement-sec-2">ETHN 357 Mexican-American History (HIST 357/LAMS 357) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 358 Native American Women (HIST 358/WMNS 358) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 362 Peoples &amp; Cultures of Africa (ANTH 362) (3 cr)</p>
-<p class="requirement-sec-2">ETHN 366 African Americans &amp; the Politics of Race: From the New Deal to the New Right (HIST 366) (3 cr)</p>
+<p class="requirement-sec-2">ETHN 366 African-Americans &amp; the Politics of Race: From the New Deal to the New Right (HIST 366) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 370 Colonial Mexico (HIST 370) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 371 Modern Mexico (HIST 371) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 373 Latin America &amp; Global Relations (HIST 373/LAMS 373) (3 cr)</p>
@@ -196,7 +196,7 @@
 <p class="requirement-sec-2">ETHN 400 Senior Seminar (3 cr)</p>
 <p class="requirement-sec-2">ETHN 425 Psychology of Racism (PSYCH 425) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 445 Ethnic Literature (ENGL 445) (3 cr)</p>
-<p class="requirement-sec-2">ETHN 445B Topics in African American Literature (ENGL 445B) (3 cr)</p>
+<p class="requirement-sec-2">ETHN 445B Topics in African-American Literature (ENGL 445B) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 445K Topics in African Literature (ENGL 445K) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 445N Topics in Native American Literature (ENGL 445N) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 451 Contemporary Issues of Indigenous People in North America (ANTH 451) (3 cr)</p>

--- a/data/2017/majors/Ethnic Studies.xhtml
+++ b/data/2017/majors/Ethnic Studies.xhtml
@@ -171,7 +171,7 @@
 <p class="requirement-sec-2">ETHN 272 Modern Latin America (HIST 272/LAMS 272) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 277 Latin American Politics (LAMS 277/POLS 277) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 285 Africa Since 1800 (HIST 285) (3 cr)</p>
-<p class="requirement-sec-2">ETHN 310 Psychology of Immingrations (PSYCH 310) (3 cr)</p>
+<p class="requirement-sec-2">ETHN 310 Psychology of Immingration (PSYCH 310) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 330 Multicultural Education (TEAC 330) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 342 History of Plains Indians (HIST 342) (3 cr)</p>
 <p class="requirement-sec-2">ETHN 344 Ethnicity &amp; Film (ENGL 344) (3 cr)</p>


### PR DESCRIPTION
The English Dept. changed the name of the ENGL/ETHN 344D, dropping African from the title.

We asked permission from the History Department to include the cross listed course HIST/ETHN 340 to our Ethnic Studies major under Group C.  It has been a cross listed course with History, but never included in our Ethnic Studies major until we requested it now.  Chair of History gave his approval.

The Institute for Ethnic Studies asked Psychology permission to include the already cross listed courses PSYCH/ETHN 310 and 425 to the Ethnic Studies minor requirements.  Chair of Psychology gave permission to include in minor course requirements.

Adding a minimum of 300 and 400 level courses to minor to put it in line with other minors in the college.