### PR TITLE
Finalize Request #11172

### DIFF
--- a/data/2017/majors/German (ASC).xhtml
+++ b/data/2017/majors/German (ASC).xhtml
@@ -81,12 +81,12 @@
 <p class="content-box-h-1">ADDITIONAL MAJOR REQUIREMENTS</p>
 <p class="title-1">Grade Rules</p>
 <p class="title-2">Pass/No Pass Limits</p>
-<p class="basic-text">No courses in the department may be taken by students majoring or minoring in modern languages for Pass/No Pass credit, with the exception of GERM 395.</p>
+<p class="basic-text">No courses in the department may be taken by students majoring or minoring in German for Pass/No Pass credit, with the exception of GERM 395.</p>
 <p class="content-box-h-1">REQUIREMENTS FOR MINOR OFFERED BY DEPARTMENT</p>
 <p class="title-2">Plan A</p>
 <p class="header-paragraph">12 hours in one language at the 300 level or 400 level, including at least 6 hours from 301, 302, 303, 304, and 3 hours at the 400 level.</p>
 <p class="title-2">Pass/No Pass Limits</p>
-<p class="basic-text">No courses in the department may be taken by students majoring or minoring in modern languages for Pass/No Pass credit, with the exception of GERM 395.</p>
+<p class="basic-text">No courses in the department may be taken by students majoring or minoring in German for Pass/No Pass credit, with the exception of GERM 395.</p>
             </div>
         </div>
     </body>

--- a/data/2017/majors/German (ASC).xhtml
+++ b/data/2017/majors/German (ASC).xhtml
@@ -19,7 +19,7 @@
                 <p class="quick-points"><span class="quick-point-bold">MINOR AVAILABLE:</span> Yes</p>
                 <p class="quick-points"><span class="quick-point-bold">ADVISOR:</span> Christina Brantner</p>
 <p class="content-box-h-1">DESCRIPTION</p>
-<p class="faculty-list"><span class="faculty-list-bold">Chair: TBD</span>, 1111 Oldfather Hall</p>
+<p class="faculty-list"><span class="faculty-list-bold">Chair: Patty Simpson</span>, 1111 Oldfather Hall</p>
 <p class="faculty-list"><span class="faculty-list-bold">Vice Chair:</span> TBD</p>
 <p class="faculty-list"><span class="faculty-list-bold">Professors:</span> Balasubramanian, Hayden-Roy, Pereira, Stump</p>
 <p class="faculty-list"><span class="faculty-list-bold">Associate Professors:</span> Amano, Brantner, González, González-Allende, Guevara, Lorenzo, Mejias-Bikandi, Shirer, Velázquez</p>

--- a/data/2017/majors/German (ASC).xhtml
+++ b/data/2017/majors/German (ASC).xhtml
@@ -2,11 +2,11 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <title>German (ASC) 16-17.xhtml</title>
+        <title>German (ASC) 17-18.xhtml</title>
         <link href="template.css" rel="stylesheet" type="text/css" />
     </head>
     <body>
-        <div id="german-asc-16-17">
+        <div id="german-asc-17-18">
             <div class="generated-style">
                 <p class="major-name">German (ASC)</p>
             </div>
@@ -81,12 +81,12 @@
 <p class="content-box-h-1">ADDITIONAL MAJOR REQUIREMENTS</p>
 <p class="title-1">Grade Rules</p>
 <p class="title-2">Pass/No Pass Limits</p>
-<p class="basic-text">No courses in the department may be taken by students majoring or minoring in modern languages for Pass/No Pass credit.</p>
+<p class="basic-text">No courses in the department may be taken by students majoring or minoring in modern languages for Pass/No Pass credit, with the exception of GERM 395.</p>
 <p class="content-box-h-1">REQUIREMENTS FOR MINOR OFFERED BY DEPARTMENT</p>
 <p class="title-2">Plan A</p>
 <p class="header-paragraph">12 hours in one language at the 300 level or 400 level, including at least 6 hours from 301, 302, 303, 304, and 3 hours at the 400 level.</p>
 <p class="title-2">Pass/No Pass Limits</p>
-<p class="basic-text">No courses in the department may be taken by students majoring or minoring in modern languages for Pass/No Pass credit.</p>
+<p class="basic-text">No courses in the department may be taken by students majoring or minoring in modern languages for Pass/No Pass credit, with the exception of GERM 395.</p>
             </div>
         </div>
     </body>


### PR DESCRIPTION
Updating bulletin section.

GERM 395 is an internship course created last year. The course is P/NP, so it would bot automatically count towards a major/minor in German. However, the Department proposes that this particular P/NP course counts towards a major or minor, since: i) the course is regularly available as part of the study abroad program in Berlin, and ii) it is believed that the course contributes to the learning outcomes identified for a German major.