### PR TITLE
Finalize Request #11207

### DIFF
--- a/data/2017/majors/Informatics Minor.xhtml
+++ b/data/2017/majors/Informatics Minor.xhtml
@@ -61,11 +61,9 @@
 <p class="requirement-sec-2">ARTP 189H University Honors Seminar; Topic: Creativity 101</p>
 <p class="requirement-sec-2">ARTS 398 Special Topics III; Topic: Creating with the iPad</p>
 <p class="requirement-sec-2">MUSC 483 Music Technology: Advanced Techniques &amp; Applications</p>
-<ul>
-<li>Credits earned using the Pass/No Pass option do not count towards this minor.</li>
-<li>In order to ensure rigor, one of the electives must be at the 300 or 400 level.</li>
-<li>Other courses, not listed as electives below, particular special topics courses, seminar courses, independent study courses or honors courses with a relevant topic may be applied toward the minor by permission of the advisor.</li>
-</ul>
+<p class="header-paragraph">Credits earned using the Pass/No Pass option do not count towards this minor.</p>
+<p class="header-paragraph">In order to ensure rigor, one of the electives must be at the 300 or 400 level.</p>
+<p class="header-paragraph">Other courses, not listed as electives, particular special topics courses, seminar courses, independent study courses or honors courses with a relevant topic, may be applied toward the minor by permission of the advisor.</p>
             </div>
         </div>
     </body>

--- a/data/2017/majors/Informatics Minor.xhtml
+++ b/data/2017/majors/Informatics Minor.xhtml
@@ -2,11 +2,11 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <title>Informatics Minor 16-17.xhtml</title>
+        <title>Informatics Minor 17-18.xhtml</title>
         <link href="template.css" rel="stylesheet" type="text/css" />
     </head>
     <body>
-        <div id="informatics-minor-16-17">
+        <div id="informatics-minor-17-18">
             <div class="generated-style">
                 <p class="major-name">Informatics Minor</p>
             </div>
@@ -42,6 +42,7 @@
 <p class="requirement-sec-2">CSCE 155T Computer Science I: Informatics Focus</p>
 <p class="requirement-sec-1">Area 2: Statistical and Research Design</p>
 <p class="requirement-sec-2">STAT 218 Introduction to Statistics</p>
+<p class="requirement-sec-2">ECON 215 Statistics</p>
 <p class="requirement-sec-2">STAT 380 Statistics &amp; Applications (MATH 380)</p>
 <p class="requirement-sec-2">EDPS 459 Statistical Methods</p>
 <p class="requirement-sec-2">PSYC 350 Research Methods &amp; Data Analysis</p>


### PR DESCRIPTION
Updating bulletin section to reflect the request by Matt Waite to list ECON 215 as part of Area 2. ECON 215 is equivalent to STAT 218, which is already on the list of Area 2 courses. 