### PR TITLE
Finalize Request #11200

### DIFF
--- a/data/2017/majors/Womens & Gender Studies.xhtml
+++ b/data/2017/majors/Womens & Gender Studies.xhtml
@@ -88,7 +88,7 @@
 <p class="requirement-sec-2">SOCI 490 Sociology of Gender (WMNS 490)</p>
 <p class="requirement-sec-2">TMFD 410 Socio-psychological Aspects of Clothing (WMNS 410A)</p>
 <p class="requirement-sec-2">*WMNS 201 Introduction to Lesbian, Gay, Bisexual, Transgender, Queer/Sexuality Studies <span class="requirement-ital">(This course may only count for one of the three areas.)</span></p>
-<p class="requirement-sec-2">WMNS 385 Women, Gender &amp; Science (AGRI 385/NRES 385)</p>
+<p class="requirement-sec-2">WMNS 385 Women, Gender &amp; Science</p>
 <p class="asterisk">* Courses that fulfill sexual diversity requirement</p>
 <p class="asterisk"># Courses that fulfill racial/ethnic/global diversity requirement</p>
 <p class="title-3">Diversity Requirement (6 hours)</p>

--- a/data/2017/majors/Womens & Gender Studies.xhtml
+++ b/data/2017/majors/Womens & Gender Studies.xhtml
@@ -2,11 +2,11 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <title>Women's &amp; Gender Studies 16-17.xhtml</title>
+        <title>Women's &amp; Gender Studies 17-18.xhtml</title>
         <link href="template.css" rel="stylesheet" type="text/css" />
     </head>
     <body>
-        <div id="women-s-gender-studies-16-17">
+        <div id="women-s-gender-studies-17-18">
             <div class="generated-style">
                 <p class="major-name">Women's &amp; Gender Studies</p>
             </div>
@@ -19,11 +19,11 @@
                 <p class="quick-points"><span class="quick-point-bold">MINOR AVAILABLE:</span> Yes</p>
                 <p class="quick-points"><span class="quick-point-bold">ADVISOR:</span> Rose Holz</p>
 <p class="content-box-h-1">DESCRIPTION</p>
-<p class="faculty-list"><span class="faculty-list-bold">Director: TBA</span></p>
+<p class="faculty-list"><span class="faculty-list-bold">Director: Margaret Jacobs, 326 Seaton Hall, 402-472-9300, mjacobs3@unl.edu</span></p>
 <p class="faculty-list"><span class="faculty-list-bold">Advisor:</span> Rose Holz, 317A Seaton Hall, 402-472-9380, rholz2@unl.edu</p>
 <p class="faculty-list"><span class="faculty-list-bold">Core Faculty:</span> Holz (women's and gender studies) and Kazyak (sociology and women's and gender studies)</p>
-<p class="faculty-list"><span class="faculty-list-bold">Program Faculty:</span> Wandsnider (anthropology); Kuska (architecture); Stewart (art and art history); Basolo (biological sciences); Reisbig (child, youth, and family studies); Crawford, Duncan, Lahey (classics and religious studies); Krone, (communication studies); May (economics); Davidson (educational psychology); Bauer, Buhler, Castro, Dreher, Foster, Gannon, Garelick, Goodburn, Homestead, Honey, Montes, Reynolds, Schleck, Stenberg, Waite (English); Mamiya (fine and performing arts); Fritz (graduate college); Ari, Curry, Jacobs, Jagodinsky, Jones, Levin, Smith (history); Poser, Shavers (law); Balasubramanian, Brantner, Carr, Gonzalez-Allende, Hasan, Peterson, Velazquez (modern languages and literatures); McKitrick (philosophy); Kang, McMahon (political science); Gervais (psychology); Deegan, Falci, McQuillan,  Werum (sociology); Heaton, Lewis, Raible, Sarroub (teaching, learning, teacher education); James (textiles, merchandising and fashion design); Woudenberg (women's and gender studies)</p>
-<p class="faculty-list"><span class="faculty-list-bold">Campus/Community Associates:</span> Burnett (honors program); Deeds (women's center/student involvement); Dunning (artist &amp; entrepreneur); Imes Borden (theatre &amp; film); Owen (English); Ross (athletics); Tetreault (LGBTQA+ resource center)</p>
+<p class="faculty-list"><span class="faculty-list-bold">Program Faculty:</span> Wandsnider (anthropology); Kuska (architecture); Stewart (art and art history); Basolo (biological sciences); Reisbig (child, youth, and family studies); Crawford, Duncan, Lahey (classics and religious studies); Krone, (communication studies); May (economics); Davidson (educational psychology); Bauer, Buhler, Castro, Dreher, Foster, Gannon, Garelick, Goodburn, Homestead, Honey, Montes, Reynolds, Schleck, Stenberg, Waite (English); Mamiya (fine and performing arts); Fritz (graduate college); Ari, Curry, Jacobs, Jagodinsky, Jones, Levin, Smith (history); Shavers (law); Balasubramanian, Brantner, Gonzalez-Allende, Hasan, Peterson, Velazquez (modern languages and literatures); McKitrick (philosophy); Kang, McMahon (political science); Gervais (psychology); Falci, McQuillan, Werum (sociology); Heaton, Lewis, Raible, Sarroub (teaching, learning, teacher education); James, Nicholas (textiles, merchandising and fashion design); Woudenberg (women's and gender studies)</p>
+<p class="faculty-list"><span class="faculty-list-bold">Campus/Community Associates:</span> Burnett (honors program); Deeds (women's center/student involvement); Dunning (artist &amp; entrepreneur); Imes Borden (theatre &amp; film); Medici-Thiemann (lecturer); Owen (English); Ross (athletics); Tetreault (LGBTQA+ resource center)</p>
 <p class="basic-text">The women's and gender studies (WGS) major is a multidisciplinary academic program with courses that focus on knowledge relating to women, gender, and sexuality.</p>
 <p class="basic-text">The program is designed to help students to learn about historical and contemporary contributions of women and to analyze the construction and representation of gender in the arts, literature, history, psychology, education, contemporary culture, politics, and society. Students are challenged to examine critically assumptions about women and gender held by academic disciplines and to evaluate them based on current research and individual experience. Students also explore sex roles, gender systems, and sexuality in various cultures as they change over time.</p>
 <p class="content-box-h-1">MAJOR REQUIREMENTS</p>
@@ -37,7 +37,7 @@
 <p class="requirement-sec-2">WMNS 400 Senior Seminar <span class="requirement-ital">(offered spring semester only)</span></p>
 <p class="requirement-sec-2">WMNS 485 Feminist Theories, Feminists' Perspectives <span class="requirement-ital">(offered fall semester only)</span></p>
 <p class="title-3">History Courses (6 hours)</p>
-<p class="requirement-sec-2">CLAS 440 Gender &amp; Sexuality in the Ancient World (WMNS 440)</p>
+<p class="requirement-sec-2">*CLAS 440 Gender &amp; Sexuality in the Ancient World (WMNS 440)</p>
 <p class="requirement-sec-2">HIST 204 Women &amp; Gender in United States History (WMNS 204)</p>
 <p class="requirement-sec-2">HIST 225 Women in History (WMNS 225)</p>
 <p class="requirement-sec-2">HIST 329 Women in European History (MRST 329/WMNS 329)</p>
@@ -46,12 +46,13 @@
 <p class="requirement-sec-2">#HIST 358 Native American Women (ETHN 358/WMNS 358)</p>
 <p class="requirement-sec-2">#HIST 363 History of Women &amp; Gender in the American West (WMNS 363)</p>
 <p class="requirement-sec-2">*HIST 402 Sexuality in 19th &amp; 20th Century America (WMNS 402)</p>
-
 <p class="requirement-sec-2">HIST 441 Seminar in U.S. Women's &amp; Gender History (WMNS 441)</p>
 <p class="requirement-sec-2">#HIST 459 Women &amp; Gender in African Societies (ETHN 459/WMNS 459/859)</p>
 <p class="requirement-sec-2">#HIST 476A Gender &amp; Sexuality in Latin America (ETHN 476A/WMNS 476A)</p>
 <p class="requirement-sec-2">*WMNS 201 Introduction to Lesbian, Gay, Bisexual, Transgender, Queer/Sexuality Studies <span class="requirement-ital">(This course may only count for one of the three areas.)</span></p>
-<p class="title-3">Literature/Rhetoric and other Humanities Courses (6 hours)</p>
+<p class="title-3"><strong>Literature/Rhetoric/Film and other Humanities Courses (6 hours)</strong></p>
+<p class="title-3">#ARAB 288 Exploring Love, Sexuality and Femininity in the History of Arabic Culture (RELG 288/WMNS 288)</p>
+<p class="title-3">#ARAB 306 Women in Quran (MRST 306/RELG 306/WMNS 306)</p>
 <p class="requirement-sec-2">*ENGL 212 Introduction to Lesbian &amp; Gay Literature (WMNS 212)</p>
 <p class="requirement-sec-2">ENGL 215 Introduction to Women's Literature (WMNS 215)</p>
 <p class="requirement-sec-2">ENGL 253A Introduction to Poetry Writing: Women's Poetry (WMNS 253A)</p>
@@ -60,11 +61,13 @@
 <p class="requirement-sec-2">#ENGL 344B Black Women Authors (ETHN 344B/WMNS 344B)</p>
 <p class="requirement-sec-2">#ENGL 345N Native American Women Writers (ETHN 345N/WMNS 345N)</p>
 <p class="requirement-sec-2">ENGL 414 Women's Literature (WMNS 414)</p>
-<p class="requirement-sec-2">*ENGL 414B Modern &amp; Contemporary Women Writers (WMNS 414B)</p>
+<p class="requirement-sec-2">ENGL 414B Modern &amp; Contemporary Women Writers (WMNS 414B)</p>
 <p class="requirement-sec-2">ENGL 475A Rhetorical Theory: Rhetoric of Women Writers (WMNS 475A)</p>
 <p class="requirement-sec-2">FREN 388 Body Language: Love, Politics, &amp; the Self in French Literature (ENGL 388/MRST 388/WMNS 388)</p>
 <p class="requirement-sec-2">JUDS 340 Women in the Biblical World (RELG 340/WMNS 340)</p>
+<p class="requirement-sec-2">#MODL 383 Women Write the World (ENGL 383/GLST 383/WMNS 383)</p>
 <p class="requirement-sec-2">PHIL 218 Philosophy of Feminism (WMNS 218)</p>
+
 <p class="requirement-sec-2">*WMNS 201 Introduction to Lesbian, Gay, Bisexual, Transgender, Queer/Sexuality Studies <span class="requirement-ital">(This course may only count for one of the three areas.)</span></p>
 <p class="title-3">Social Sciences Courses (6 hours)</p>
 <p class="requirement-sec-2">ANTH 410 Gender: An Anthropological Perspective (WMNS 410)</p>
@@ -76,7 +79,7 @@
 <p class="requirement-sec-2">POLS 338 Women &amp; Politics (WMNS 338)</p>
 <p class="requirement-sec-2">*PSYC 330 Psychology of Diversity</p>
 <p class="requirement-sec-2">PSYC 421 Psychology of Gender (WMNS 421)</p>
-<p class="requirement-sec-2">PSYC 471 Human Sexuality &amp; Society (CYAF 471/EDPS 471/SOCI 471)</p>
+<p class="requirement-sec-2">*PSYC 471 Human Sexuality &amp; Society (CYAF 471/EDPS 471/SOCI 471)</p>
 <p class="requirement-sec-2">SOCI 200 Gender in Contemporary Society (WMNS 200)</p>
 <p class="requirement-sec-2">SOCI 226 Families &amp; Society (WMNS 226)</p>
 <p class="requirement-sec-2">SOCI 325 Contemporary Family Issues (WMNS 325)</p>
@@ -108,7 +111,7 @@
 <p class="asterisk">* Courses that fulfill sexual diversity requirement</p>
 <p class="asterisk"># Courses that fulfill racial/ethnic/global diversity requirement</p>
 <p class="header-paragraph"><span class="header-paragraph-title">Program Assessment.</span> In order to assist the department in evaluating the effectiveness of its programs, majors will be required:</p>
-<p class="numbered-list">1. To submit for assessment during WMNS 400 (Senior Seminar) an electronic portfolio of student work including: 1) a critical synthetic overview of the items in the portfolio; 2) an assignment from a WGS history class + critical reflection; 3) an assignment from a WGS social sciences class + critical reflection; 4) an assignment from a WGS literature/film class + critical reflection; 5) an assignment from WMNS 485 + critical reflection; and 6) the final paper/project from WMNS 400. <span class="basic-text-bold">NOTE:</span> If a student has written an undergraduate thesis (through WGS or the honors program) on women, gender, and/or sexuality, this should be included as well. </p>
+<p class="numbered-list">1. To submit for assessment during WMNS 400 (Senior Seminar) an electronic portfolio of student work including: 1) a critical synthetic overview of the items in the portfolio; 2) an assignment from a WGS history class + critical reflection; 3) an assignment from a WGS social sciences class + critical reflection; 4) an assignment from a WGS literature/film class + critical reflection; 5) an assignment from WMNS 485 + critical reflection; and 6) the final paper/project from WMNS 400. <span class="basic-text-bold">NOTE:</span> If a student has written an undergraduate thesis (through WGS or the honors program) on women, gender, and/or sexuality, this should be included as well.</p>
 <p class="numbered-list">2. In their last semester, to return an anonymous survey regarding the WGS program and, if the student wishes, to participate in an exit interview with the director or associate director.</p>
 <p class="numbered-list">Results of participation in this assessment activity will in no way affect a student’s GPA or graduation.</p>
 <p class="content-box-h-1">ADDITIONAL MAJOR REQUIREMENTS</p>
@@ -119,7 +122,7 @@
 <p class="content-box-h-1">REQUIREMENTS FOR MINOR OFFERED BY DEPARTMENT</p>
 <p class="requirement-sec-1">18 hours of courses in the women's and gender studies program, including:</p>
 <p class="requirement-sec-2">– WMNS 101 Introduction to Women's &amp; Gender Studies (3 hrs)</p>
-<p class="requirement-sec-2">– 3 hours each from courses listed under history; literature/rhetoric and other humanities; and social sciences</p>
+<p class="requirement-sec-2">– 3 hours each from courses listed under history; literature/rhetoric/film and other humanities; and social sciences</p>
 <ul>
 <li>At least 6 hours of courses at the 300 level or above</li>
 <li>At least 3 hours of courses that fulfill the diversity requirement <span class="basic-text-ital">(Courses designated with an * or # satisfy this requirement.)</span></li>

--- a/data/2017/majors/Womens & Gender Studies.xhtml
+++ b/data/2017/majors/Womens & Gender Studies.xhtml
@@ -22,7 +22,7 @@
 <p class="faculty-list"><span class="faculty-list-bold">Director: Margaret Jacobs, 326 Seaton Hall, 402-472-9300, mjacobs3@unl.edu</span></p>
 <p class="faculty-list"><span class="faculty-list-bold">Advisor:</span> Rose Holz, 317A Seaton Hall, 402-472-9380, rholz2@unl.edu</p>
 <p class="faculty-list"><span class="faculty-list-bold">Core Faculty:</span> Holz (women's and gender studies) and Kazyak (sociology and women's and gender studies)</p>
-<p class="faculty-list"><span class="faculty-list-bold">Program Faculty:</span> Wandsnider (anthropology); Kuska (architecture); Stewart (art and art history); Basolo (biological sciences); Reisbig (child, youth, and family studies); Crawford, Duncan, Lahey (classics and religious studies); Krone, (communication studies); May (economics); Davidson (educational psychology); Bauer, Buhler, Castro, Dreher, Foster, Gannon, Garelick, Goodburn, Homestead, Honey, Montes, Reynolds, Schleck, Stenberg, Waite (English); Mamiya (fine and performing arts); Fritz (graduate college); Ari, Curry, Jacobs, Jagodinsky, Jones, Levin, Smith (history); Shavers (law); Balasubramanian, Brantner, Gonzalez-Allende, Hasan, Peterson, Velazquez (modern languages and literatures); McKitrick (philosophy); Kang, McMahon (political science); Gervais (psychology); Falci, McQuillan, Werum (sociology); Heaton, Lewis, Raible, Sarroub (teaching, learning, teacher education); James, Nicholas (textiles, merchandising and fashion design); Woudenberg (women's and gender studies)</p>
+<p class="faculty-list"><span class="faculty-list-bold">Program Faculty:</span> Wandsnider (anthropology); Kuska (architecture); Stewart (art and art history); Basolo (biological sciences); Reisbig (child, youth, and family studies); Crawford, Duncan, Lahey (classics and religious studies); Krone, (communication studies); May (economics); Davidson (educational psychology); Bauer, Buhler, Castro, Dreher, Foster, Gannon, Garelick, Goodburn, Homestead, Honey, Montes, Reynolds, Schleck, Stenberg, Waite (English); Mamiya (fine and performing arts); Fritz (graduate college); Ari, Curry, Jacobs, Jagodinsky, Jones, Levin, Smith (history); Shavers (law); Balasubramanian, Brantner, Gonzalez-Allende, Hasan, Peterson, Rodriguez, Velazquez (modern languages and literatures); McKitrick (philosophy); Kang, McMahon (political science); Hope, Gervais (psychology); Burke, Falci, McQuillan, Werum (sociology); Heaton, Lewis, Raible, Sarroub (teaching, learning, teacher education); James, Nicholas (textiles, merchandising and fashion design); Woudenberg (women's and gender studies)</p>
 <p class="faculty-list"><span class="faculty-list-bold">Campus/Community Associates:</span> Burnett (honors program); Deeds (women's center/student involvement); Dunning (artist &amp; entrepreneur); Imes Borden (theatre &amp; film); Medici-Thiemann (lecturer); Owen (English); Ross (athletics); Tetreault (LGBTQA+ resource center)</p>
 <p class="basic-text">The women's and gender studies (WGS) major is a multidisciplinary academic program with courses that focus on knowledge relating to women, gender, and sexuality.</p>
 <p class="basic-text">The program is designed to help students to learn about historical and contemporary contributions of women and to analyze the construction and representation of gender in the arts, literature, history, psychology, education, contemporary culture, politics, and society. Students are challenged to examine critically assumptions about women and gender held by academic disciplines and to evaluate them based on current research and individual experience. Students also explore sex roles, gender systems, and sexuality in various cultures as they change over time.</p>
@@ -37,7 +37,7 @@
 <p class="requirement-sec-2">WMNS 400 Senior Seminar <span class="requirement-ital">(offered spring semester only)</span></p>
 <p class="requirement-sec-2">WMNS 485 Feminist Theories, Feminists' Perspectives <span class="requirement-ital">(offered fall semester only)</span></p>
 <p class="title-3">History Courses (6 hours)</p>
-<p class="requirement-sec-2">*CLAS 440 Gender &amp; Sexuality in the Ancient World (WMNS 440)</p>
+<p class="requirement-sec-2">CLAS 440 Gender &amp; Sexuality in the Ancient World (WMNS 440)</p>
 <p class="requirement-sec-2">HIST 204 Women &amp; Gender in United States History (WMNS 204)</p>
 <p class="requirement-sec-2">HIST 225 Women in History (WMNS 225)</p>
 <p class="requirement-sec-2">HIST 329 Women in European History (MRST 329/WMNS 329)</p>
@@ -53,13 +53,15 @@
 <p class="title-3"><strong>Literature/Rhetoric/Film and other Humanities Courses (6 hours)</strong></p>
 <p class="title-3">#ARAB 288 Exploring Love, Sexuality and Femininity in the History of Arabic Culture (RELG 288/WMNS 288)</p>
 <p class="title-3">#ARAB 306 Women in Quran (MRST 306/RELG 306/WMNS 306)</p>
-<p class="requirement-sec-2">*ENGL 212 Introduction to Lesbian &amp; Gay Literature (WMNS 212)</p>
+<p class="requirement-sec-2">*ENGL 212 Introduction to LGBTQ Literature (WMNS 212)</p>
 <p class="requirement-sec-2">ENGL 215 Introduction to Women's Literature (WMNS 215)</p>
 <p class="requirement-sec-2">ENGL 253A Introduction to Poetry Writing: Women's Poetry (WMNS 253A)</p>
+<p class="requirement-sec-2">*ENGL 312 LGBTQ Literature and Film (WMNS 312)</p>
 <p class="requirement-sec-2">ENGL 315A Survey of Women's Literature (WMNS 315A)</p>
 <p class="requirement-sec-2">ENGL 315B Women in Popular Culture (WMNS 315B)</p>
 <p class="requirement-sec-2">#ENGL 344B Black Women Authors (ETHN 344B/WMNS 344B)</p>
 <p class="requirement-sec-2">#ENGL 345N Native American Women Writers (ETHN 345N/WMNS 345N)</p>
+<p class="requirement-sec-2">*ENGL 401K LGBTQ Drama and Popular Culture (WMNS 401K)</p>
 <p class="requirement-sec-2">ENGL 414 Women's Literature (WMNS 414)</p>
 <p class="requirement-sec-2">ENGL 414B Modern &amp; Contemporary Women Writers (WMNS 414B)</p>
 <p class="requirement-sec-2">ENGL 475A Rhetorical Theory: Rhetoric of Women Writers (WMNS 475A)</p>


### PR DESCRIPTION
ARAB 288, ARAB 306, and MODL 383 -- These were all approved last year and cross-listed with WGS. Given their subject matter, they all should count towards in the Literature/Rhetoric/Film and Other Humanities Categories. They also should count towards WGS's racial/global diversity requirement.

ENGL/WMNS 212 -- The English department changed the name.

ENGL/WMNS 312 -- New English department course. We've approved the cross-list. It should also count towards WGS literature and sexual diversity requirements.

ENGL/WMNS 401K -- Newly cross-listed with WGS and should count towards WGS literature and sexual diversity requirements.

PSYC 471 Human Sexuality & Society -- This should count towards sexual diversity requirement.

Adding "Film" to Literature/Rhetoric/Film and other Humanities Courses category -- Although film courses don't readily appear in the list of courses allowed, adding Film allows for a more accurate representation of courses the students can/do take to fulfill this requirement -- because these are usually offered as special topics.

Removing asterisk by ENGL/WMNS 414B Modern & Contemporary Women Writers. For some reason this was added as a sexual diversity class last year. It was a mistake and should not be designated as such.

WMNS/AGRI/NRES 385 -- WGS has chosen to remove all cross-lists from its stand-alone courses. Our goal in so doing is to allow these courses to be taught from any disciplinary perspective without worrying about failing to meet the disciplinary requirements of cross-listed departments. AGRI and NRES have been notified. Once we hear back from both units, we will put in the course change request to have the cross-lists officially removed from the bulletin.
