### PR TITLE
Finalize Request #11175

### DIFF
--- a/data/2017/majors/Great Plains Studies.xhtml
+++ b/data/2017/majors/Great Plains Studies.xhtml
@@ -14,7 +14,7 @@
                 <p class="quick-points"><span class="quick-point-bold">COLLEGE:</span> Arts &amp; Sciences</p>
                 <p class="quick-points"><span class="quick-point-bold">MAJOR:</span> Great Plains Studies</p>
                 <p class="quick-points"><span class="quick-point-bold">DEGREE OFFERED:</span> Minor Only</p>
-                <p class="quick-points"><span class="quick-point-bold">HOURS REQUIRED:</span> 15</p>
+                <p class="quick-points"><span class="quick-point-bold">HOURS REQUIRED:</span> 18</p>
                 <p class="quick-points"><span class="quick-point-bold">MINIMUM CUMULATIVE GPA:</span> </p>
                 <p class="quick-points"><span class="quick-point-bold">MINOR AVAILABLE:</span> Yes</p>
                 <p class="quick-points"><span class="quick-point-bold">ADVISOR:</span> Charles Braithwaite</p>
@@ -26,12 +26,12 @@
 <p class="title-1"><span class="header-paragraph-title"></span></p>
 <p class="title-3"><sup></sup></p>
 <p class="content-box-h-1">REQUIREMENTS FOR MINOR OFFERED BY DEPARTMENT</p>
-<p class="requirement-sec-1">15 credits—no more than 6 cr from one department; 6 cr at 300/400 level:</p>
-<p class="requirement-sec-2">GPSP 170 Introduction to Great Plains Studies (ANTH 170/GEOG 170/NRES 170/SOCI 170) (3 cr)</p>
-<p class="requirement-sec-2">GPSP 400 Seminar in Great Plains Studies (GEOG 400/HIST 400) (3 cr)</p>
-<p class="requirement-sec-2">6 credits from two of the three Thematic Specializations; 3 credits to be chosen from among courses in thematic specializations, courses-at-large, internship, or independent study.</p>
-<p>Thematic Specializations</p>
-<p>All majors must take at least 18 hours to be distributed in two of the following areas:</p>
+<p class="requirement-sec-1">18 credits—no more than 6 cr from one department; 6 cr at 300/400 level, including:</p>
+<p class="requirement-sec-2">A. GPSP 170 Introduction to Great Plains Studies (ANTH 170/GEOG 170/NRES 170/SOCI 170) (3 cr)</p>
+
+
+<p>B. Thematic Specializations (12 cr) - 6 credits from two of the three Thematic Specializations;</p>
+
 <p>Arts and Literature</p>
 <p>AHIS 252 American Art 1865-1945 (3 cr)</p>
 <p>AHIS 451/851 19th Century American Art (3 cr)</p>
@@ -84,8 +84,8 @@
 <p>NRES 220 Principles Of Ecology (BIOS 220) (3 cr)</p>
 <p>NRES 310 Introduction to Forest Management (3 cr)</p>
 <p>NRES 452 Climate &amp; Society (AGRO 450/GEOG 450/METR 450) (3 cr)</p>
-<p>C. Great Plains Courses at Large</p>
-<p>Courses can be taken from above categories, in addition to those listed below</p>
+<p>C. Great Plains Courses at Large (3 cr) - 3 additional credits to be chosen from among courses in thematic specializations above or from the courses-at-large below.  </p>
+
 <p>AECN 201 Farm &amp; Ranch Management (4 cr)</p>
 <p>AECN 376 Rural Community Economics (3 cr)</p>
 <p>AECN 456 Environmental Law (NREE 456) (3 cr)</p>
@@ -109,6 +109,8 @@
 <p>GEOG 271 Geography of the U.S. (3 cr)</p>
 <p>GEOL 457 Ecosystem Ecology (BIOS 457) (4 cr)</p>
 <p>GEOG 467 Great Plains Field Pedology (AGRO 477/NRES 477/SOIL 477) (4 cr)</p>
+<p>GPSP 399  Independent Directed Reading (1-3 cr)</p>
+<p>GPSP 399H Honors Course (1-3 cr)</p>
 <p>GPSP 495 Great Plains Internship (1-6 cr)</p>
 <p>HIST 244 19<sup>th</sup> Century America (3 cr)</p>
 <p>HIST 247 African-American History After 1877 (ETHN 247) (3 cr)</p>

--- a/data/2017/majors/Great Plains Studies.xhtml
+++ b/data/2017/majors/Great Plains Studies.xhtml
@@ -2,143 +2,122 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <title>Great Plains Studies 16-17.xhtml</title>
+        <title>Great Plains Studies 17-18.xhtml</title>
         <link href="template.css" rel="stylesheet" type="text/css" />
     </head>
     <body>
-        <div id="great-plains-studies-16-17">
+        <div id="great-plains-studies-17-18">
             <div class="generated-style">
                 <p class="major-name">Great Plains Studies</p>
             </div>
             <div class="generated-style">
                 <p class="quick-points"><span class="quick-point-bold">COLLEGE:</span> Arts &amp; Sciences</p>
                 <p class="quick-points"><span class="quick-point-bold">MAJOR:</span> Great Plains Studies</p>
-                <p class="quick-points"><span class="quick-point-bold">DEGREE OFFERED:</span> Bachelor of Arts or Bachelor of Science</p>
-                <p class="quick-points"><span class="quick-point-bold">HOURS REQUIRED:</span> 120</p>
-                <p class="quick-points"><span class="quick-point-bold">MINIMUM CUMULATIVE GPA:</span> 2.0 for graduation</p>
+                <p class="quick-points"><span class="quick-point-bold">DEGREE OFFERED:</span> Minor Only</p>
+                <p class="quick-points"><span class="quick-point-bold">HOURS REQUIRED:</span> 15</p>
+                <p class="quick-points"><span class="quick-point-bold">MINIMUM CUMULATIVE GPA:</span> </p>
                 <p class="quick-points"><span class="quick-point-bold">MINOR AVAILABLE:</span> Yes</p>
                 <p class="quick-points"><span class="quick-point-bold">ADVISOR:</span> Charles Braithwaite</p>
 <p class="content-box-h-1">DESCRIPTION</p>
 <p class="faculty-list"><span class="faculty-list-bold">Director: Richard Edwards,</span> 1155 Q Street, Room 306</p>
 <p class="faculty-list"><span class="faculty-list-bold">Advisor:</span> Charles Braithwaite, 1155 Q Street, Room 504</p>
-<p class="basic-text">Great Plains Studies is an interdisciplinary/ intercollegiate program of the Center for Great Plains Studies, 1155 Q Street. A major or minor in Great Plains Studies is a useful program for students who plan a career in business, education, planning, policy analysis, agriculture, public relations, marketing, and any profession or career where an in-depth understanding of the Pains region would be advantageous. Courses that comprise the program are based in the following cooperating departments: African American and African Studies; Agricultural Economics; Agronomy; Anthropology and Geography; Architecture; Art and Art History; Biological Sciences; Communication Studies; Community and Regional Planning; Earth and Atmospheric Sciences; English; Ethnic Studies; History; Latino and Latin American Studies; Modern Languages and Literatures; Music; Native American Studies; Natural Resource Sciences; Political Science; Sociology; and Women and Gender Studies. Internships are strongly encouraged and may be used to fulfill major or minor requirements. The Frances W. Kaye Scholarship for $500 is awarded each year to a Great Plains major.</p>
+<p class="basic-text">Great Plains Studies is an interdisciplinary/ intercollegiate program of the Center for Great Plains Studies, 1155 Q Street. A  minor in Great Plains Studies is a useful program for students who plan a career in business, education, planning, policy analysis, agriculture, public relations, marketing, and any profession or career where an in-depth understanding of the Pains region would be advantageous. Courses that comprise the program are based in the following cooperating departments: African American and African Studies; Agricultural Economics; Agronomy; Anthropology and Geography; Architecture; Art and Art History; Biological Sciences; Communication Studies; Community and Regional Planning; Earth and Atmospheric Sciences; English; Ethnic Studies; History; Latino and Latin American Studies; Modern Languages and Literatures; Music; Native American Studies; Natural Resource Sciences; Political Science; Sociology; and Women and Gender Studies. Internships are strongly encouraged and may be used to fulfill minor requirements. </p>
 <p class="content-box-h-1">MAJOR REQUIREMENTS</p>
-<p class="title-1">Specific Major Requirements</p>
-<ul>
-<li>30 credits, with no more than 12 credits from one department; at least 12 credits at the 300/400 level.</li>
-</ul>
-<p class="basic-text">Core Courses (6 cr): GPSP 170 Introduction to Great Plains Studies (3 cr), and GPSP 400 Seminar in Great Plains Studies (3 cr).</p>
-<p class="basic-text">Thematic Specializations (18 cr): 18 cr in two of the three thematic specializations: Arts &amp; Literature; Culture &amp; Community; and Land &amp; Environment.</p>
-<p class="basic-text">The remaining 6 cr can be taken from other courses listed under these categories, from at-large courses, internships, or as independent study.</p>
-<p class="header-paragraph">The courses should be chosen in such a way as to construct a thematically or professionally coherent program. Other courses or independent study may be substituted for some of the courses listed with permission of the advisor. The advisor may also assign an advisor for each student from among the faculty fellows of the Center.</p>
-<p class="header-paragraph"><span class="header-paragraph-title">Program Assessment.</span> In order to assist the department in evaluating the effectiveness of its programs, majors will be required:</p>
-<p class="numbered-list">1. To develop a portfolio consisting of materials from Great Plains course work, to be submitted to the advisor prior to graduation. The portfolio should include a research paper from the Seminar in Great Plains Studies, GPSP 400, as well as papers from at least three other courses that apply to the major.</p>
-<p class="numbered-list">2. In their senior year, to participate in an exit interview. The advisor will inform students of the scheduling and format of assessment activities.</p>
-<p class="header-paragraph">Results of participation in this assessment activity will in no way affect a students GPA or graduation.</p>
-<p class="title-3">A. Core Courses</p>
-<p class="requirement-sec-2">GPSP 170 Introduction to Great Plains Studies (ANTH 170/GEOG 170/NRES 170/SOCI 170) (3 cr)</p>
-<p class="requirement-sec-2">GPSP 400 Seminar in Great Plains Studies (GEOG 400/HIST 400) (3 cr)</p>
-<p class="title-3">B. Thematic Specializations</p>
-<p class="requirement-sec-2">All majors must take at least 18 hours to be distributed in two of the following areas:</p>
-<p class="requirement-sec-1">Arts and Literature</p>
-<p class="requirement-sec-2">AHIS 252 American Art 1865-1945 (3 cr)</p>
-<p class="requirement-sec-2">AHIS 451/851 19th Century American Art (3 cr)</p>
-<p class="requirement-sec-2">AHIS 452 American Art, 1893-1939 (3 cr)</p>
-<p class="requirement-sec-2">ANTH 419 Art &amp; Anthropology of Native North Americans (3 cr)</p>
-<p class="requirement-sec-2">ENGL 211 Literature of Place (3 cr)</p>
-<p class="requirement-sec-2">ENGL 244 African-American Literature Since 1865 (ETHN 244) (3 cr)</p>
-<p class="requirement-sec-2">ENGL 245N Introduction to Native American Literature (ETHN 245N) (3 cr)</p>
-<p class="requirement-sec-2">ENGL 317 Literature &amp; the Environment (3 cr)</p>
-<p class="requirement-sec-2">ENGL 333A Willa Cather &amp; Her World (3 cr)</p>
-<p class="requirement-sec-2">ENGL 347 Humanities on the Plains (3 cr)</p>
-<p class="requirement-sec-2">ENGL 405K Canadian Fiction (3 cr)</p>
-<p class="requirement-sec-2">ENGL 445N Topics in Native American Literature (ETHN 445N) (3 cr)</p>
-<p class="requirement-sec-2">MUSC 489 American Music (3 cr)</p>
-<p class="requirement-sec-1">Culture and Community</p>
-<p class="requirement-sec-2">ANTH 130 Anthropology of the Great Plains (3 cr)</p>
-<p class="requirement-sec-2">ANTH 350 Peoples &amp; Cultures of Native Latin America (ETHN 350) (3 cr)</p>
-<p class="requirement-sec-2">ANTH 351 Indigenous Peoples of North America (ETHN 351) (3 cr)</p>
-<p class="requirement-sec-2">ANTH 352 Indigenous Peoples of the Great Plains (ETHN 352) (3 cr)</p>
-<p class="requirement-sec-2">ANTH 434 Introduction to Great Plains Archaeology (3 cr)</p>
-<p class="requirement-sec-2">ANTH 451 Contemporary Issues of Indigenous Peoples in North America (ETHN 451) (3 cr)</p>
-<p class="requirement-sec-2">GEOG 334 Historical Geography of the Great Plains (3 cr)</p>
-<p class="requirement-sec-2">GEOG 435 Cultural Survival: Indigenous People's Rights (3 cr)</p>
-<p class="requirement-sec-2">GPSP 377 Women of the Great Plains (GEOG 377/WMNS 377) (3 cr)</p>
-<p class="requirement-sec-2">GPSP 378 Cultural Encounters on the Great Plains (COMM 378) (3 cr)</p>
-<p class="requirement-sec-2">HIST 241 Native American History (ETHN 241) (3 cr)</p>
-<p class="requirement-sec-2">HIST 342 History of Plains Indians (ETHN 342) (3 cr)</p>
-<p class="requirement-sec-2">HIST 352 American West Since 1900 (3 cr)</p>
-<p class="requirement-sec-2">HIST 356 African-American Women's History (ETHN 356/WMNS 356) (3 cr)</p>
-<p class="requirement-sec-2">HIST 357 Mexican-American History (ETHN 357/LAMS 357) (3 cr)</p>
-<p class="requirement-sec-2">HIST 358 Native American Women (ETHN 358/WMNS 358) (3 cr)</p>
-<p class="requirement-sec-2">HIST 359 The Mythic West (3 cr)</p>
-<p class="requirement-sec-2">HIST 360 History of Nebraska &amp; the Great Plains (3 cr)</p>
-
-<p class="requirement-sec-2">POLS 225 Nebraska Government &amp; Politics (3 cr)</p>
-<p class="requirement-sec-1">Land and Environment</p>
-<p class="requirement-sec-2">AECN 265 Resource &amp; Environmental Economics I (NREE 265) (3 cr)</p>
-<p class="requirement-sec-2">AECN 276 Rural Sociology (SOCI 241) (3 cr)</p>
-<p class="requirement-sec-2">AECN 345 Policy Issues in Agriculture &amp; Natural Resources (3 cr)</p>
-<p class="requirement-sec-2">AECN 388 Ethics in Agriculture &amp; Natural Resources (ALEC 388) (3 cr)</p>
-<p class="requirement-sec-2">AGRO 153 Soil Resources (HORT 153/SOIL 153) (4 cr)</p>
-<p class="requirement-sec-2">AGRO 228 Introduction to Landscape Management (HORT 228/TLMT 228) (3 cr)</p>
-<p class="requirement-sec-2">AGRO 242 North American Wildland Plants (HORT 242/RNGE 242) (3 cr)</p>
-<p class="requirement-sec-2">AGRO 440 Great Plains Ecosystem (NRES 440/RNGE 440) (3 cr)</p>
-<p class="requirement-sec-2">BIOS 232 Ecological Issues in the Great Plains (3 cr)</p>
-<p class="requirement-sec-2">BIOS 455 Great Plains Flora (3 cr)</p>
-<p class="requirement-sec-2">ENVR 201 Science, Systems, Environment, &amp; Sustainability (3 cr)</p>
-<p class="requirement-sec-2">GEOG 305 Geography of Agriculture (AGRO 305/HORT 305) (3 cr)</p>
-<p class="requirement-sec-2">GEOG 370 Geography of Nebraska (3 cr)</p>
-<p class="requirement-sec-2">HORT 495 Grasslands Seminar (AGRO 495/ENTO 495/GRAS 495/NRES 495) (1-2 cr)</p>
-<p class="requirement-sec-2">NRES 220 Principles Of Ecology (BIOS 220) (3 cr)</p>
-<p class="requirement-sec-2">NRES 310 Introduction to Forest Management (3 cr)</p>
-<p class="requirement-sec-2">NRES 452 Climate &amp; Society (AGRO 450/GEOG 450/METR 450) (3 cr)</p>
-<p class="title-3">C. Great Plains Courses at Large</p>
-<p class="requirement-sec-2">Courses can be taken from above categories, in addition to those listed below</p>
-<p class="requirement-sec-2">AECN 201 Farm &amp; Ranch Management (4 cr)</p>
-<p class="requirement-sec-2">AECN 376 Rural Community Economics (3 cr)</p>
-<p class="requirement-sec-2">AECN 456 Environmental Law (NREE 456) (3 cr)</p>
-<p class="requirement-sec-2">AECN 457 Water Law (NREE 457/WATS 457) (3 cr)</p>
-<p class="requirement-sec-2">AGRO 240 Forage Crop &amp; Pasture Management (RNGE 240) (3 cr)</p>
-<p class="requirement-sec-2">AGRO 326 Landscape Solutions (HORT 326/TLMT 326) (3 cr)</p>
-<p class="requirement-sec-2">AGRO 442 Wildland Plants (RNGE 442/NRES 442) (3 cr)</p>
-
-
-<p class="requirement-sec-2">ANTH 290/490 Fieldwork in Anthropology (1-6 cr)</p>
-<p class="requirement-sec-2">ANTH 433 North American Archeology (3 cr)</p>
-<p class="requirement-sec-2">ANTH 454 Ethnographic Fieldschool (Great Plains Sections) (1-6 cr)</p>
-<p class="requirement-sec-2">BIOS 470 Prairie Ecology (Cedar Point) (4 cr)</p>
-<p class="requirement-sec-2">BIOS 475 Ornithology (Cedar Point) (3 cr)</p>
-<p class="requirement-sec-2">BIOS 476 Mammalogy (NRES 476) (4 cr)</p>
-<p class="requirement-sec-2">BIOS 482 Field Entomology (Cedar Point) (ENTO 411) (4 cr)</p>
-<p class="requirement-sec-2">BIOS 487 Field Parasitology (Cedar Point) (4 cr)</p>
-<p class="requirement-sec-2">BIOS 488 Natural History of the Invertebrates (Cedar Point) (4 cr)</p>
-<p class="requirement-sec-2">BIOS 489 Ichthyology (Cedar Point) (NRES 489) (4 cr)</p>
-<p class="requirement-sec-2">ENGL 261 American Literature Since 1865 (3 cr)</p>
-<p class="requirement-sec-2">ENGL 345N Native American Women Writers (ETHN 345N/WMNS 345N) (3 cr)</p>
-<p class="requirement-sec-2">ENVR 319 Environmental Engagement &amp; the Community (2 cr)</p>
-<p class="requirement-sec-2">GEOG 271 Geography of the U.S. (3 cr)</p>
-<p class="requirement-sec-2">GEOL 457 Ecosystem Ecology (BIOS 457) (4 cr)</p>
-<p class="requirement-sec-2">GEOG 467 Great Plains Field Pedology (AGRO 477/NRES 477/SOIL 477) (4 cr)</p>
-<p class="requirement-sec-2">GPSP 495 Great Plains Internship (1-6 cr)</p>
-<p class="requirement-sec-2">HIST 244 19<sup>th</sup> Century America (3 cr)</p>
-<p class="requirement-sec-2">HIST 247 African-American History After 1877 (ETHN 247) (3 cr)</p>
-<p class="requirement-sec-2">HIST 346 North American Environmental History (3 cr)</p>
-<p class="requirement-sec-2">HIST 363 History of Women &amp; Gender in the American West (WMNS 363) (3 cr)</p>
-<p class="requirement-sec-2">HIST 464 Native American History-Selected Topics (ETHN 464) (3 cr)</p>
-<p class="requirement-sec-2">NRES 417 Agroforestry Systems in Sustainable Agriculture (HORT 418) (3 cr)</p>
-<p class="requirement-sec-2">SOCI 217 Sociology of Race &amp; Ethnicity (ETHN 217) (3 cr)</p>
-<p class="requirement-sec-2">SOCI 346 Environmental Sociology (3 cr)</p>
-<p class="content-box-h-1">ADDITIONAL MAJOR REQUIREMENTS</p>
-<p class="title-1">Course Level Requirement</p>
-<p class="basic-text">At least 12 credits of course work must be at the 300 and 400 levels.</p>
-<p class="title-1">Extended Education, Independent Study Rules, Internship Credit Rules</p>
-<p class="basic-text">Up to 6 credits of suitable internship work can be included in the 30 hours required for the major, and Great Plains Studies students are strongly encouraged to pursue an internship through Career Services: Student Jobs and Internships as part of their program.</p>
+<p class="title-1"><span class="header-paragraph-title"></span></p>
+<p class="title-3"><sup></sup></p>
 <p class="content-box-h-1">REQUIREMENTS FOR MINOR OFFERED BY DEPARTMENT</p>
 <p class="requirement-sec-1">15 credits—no more than 6 cr from one department; 6 cr at 300/400 level:</p>
 <p class="requirement-sec-2">GPSP 170 Introduction to Great Plains Studies (ANTH 170/GEOG 170/NRES 170/SOCI 170) (3 cr)</p>
 <p class="requirement-sec-2">GPSP 400 Seminar in Great Plains Studies (GEOG 400/HIST 400) (3 cr)</p>
 <p class="requirement-sec-2">6 credits from two of the three Thematic Specializations; 3 credits to be chosen from among courses in thematic specializations, courses-at-large, internship, or independent study.</p>
+<p>Thematic Specializations</p>
+<p>All majors must take at least 18 hours to be distributed in two of the following areas:</p>
+<p>Arts and Literature</p>
+<p>AHIS 252 American Art 1865-1945 (3 cr)</p>
+<p>AHIS 451/851 19th Century American Art (3 cr)</p>
+<p>AHIS 452 American Art, 1893-1939 (3 cr)</p>
+<p>ANTH 419 Art &amp; Anthropology of Native North Americans (3 cr)</p>
+<p>ENGL 211 Literature of Place (3 cr)</p>
+<p>ENGL 244 African-American Literature Since 1865 (ETHN 244) (3 cr)</p>
+<p>ENGL 245N Introduction to Native American Literature (ETHN 245N) (3 cr)</p>
+<p>ENGL 317 Literature &amp; the Environment (3 cr)</p>
+<p>ENGL 333A Willa Cather &amp; Her World (3 cr)</p>
+<p>ENGL 347 Humanities on the Plains (3 cr)</p>
+<p>ENGL 405K Canadian Fiction (3 cr)</p>
+<p>ENGL 445N Topics in Native American Literature (ETHN 445N) (3 cr)</p>
+<p>MUSC 489 American Music (3 cr)</p>
+<p>Culture and Community</p>
+<p>ANTH 130 Anthropology of the Great Plains (3 cr)</p>
+<p>ANTH 350 Peoples &amp; Cultures of Native Latin America (ETHN 350) (3 cr)</p>
+<p>ANTH 351 Indigenous Peoples of North America (ETHN 351) (3 cr)</p>
+<p>ANTH 352 Indigenous Peoples of the Great Plains (ETHN 352) (3 cr)</p>
+<p>ANTH 434 Introduction to Great Plains Archaeology (3 cr)</p>
+<p>ANTH 451 Contemporary Issues of Indigenous Peoples in North America (ETHN 451) (3 cr)</p>
+<p>GEOG 334 Historical Geography of the Great Plains (3 cr)</p>
+<p>GEOG 435 Cultural Survival: Indigenous People's Rights (3 cr)</p>
+<p>GPSP 377 Women of the Great Plains (GEOG 377/WMNS 377) (3 cr)</p>
+<p>GPSP 378 Cultural Encounters on the Great Plains (COMM 378) (3 cr)</p>
+<p>HIST 241 Native American History (ETHN 241) (3 cr)</p>
+<p>HIST 342 History of Plains Indians (ETHN 342) (3 cr)</p>
+<p>HIST 352 American West Since 1900 (3 cr)</p>
+<p>HIST 356 African-American Women's History (ETHN 356/WMNS 356) (3 cr)</p>
+<p>HIST 357 Mexican-American History (ETHN 357/LAMS 357) (3 cr)</p>
+<p>HIST 358 Native American Women (ETHN 358/WMNS 358) (3 cr)</p>
+<p>HIST 359 The Mythic West (3 cr)</p>
+<p>HIST 360 History of Nebraska &amp; the Great Plains (3 cr)</p>
+<p>POLS 225 Nebraska Government &amp; Politics (3 cr)</p>
+<p>Land and Environment</p>
+<p>AECN 265 Resource &amp; Environmental Economics I (NREE 265) (3 cr)</p>
+<p>AECN 276 Rural Sociology (SOCI 241) (3 cr)</p>
+<p>AECN 345 Policy Issues in Agriculture &amp; Natural Resources (3 cr)</p>
+<p>AECN 388 Ethics in Agriculture &amp; Natural Resources (ALEC 388) (3 cr)</p>
+<p>AGRO 153 Soil Resources (HORT 153/SOIL 153) (4 cr)</p>
+<p>AGRO 228 Introduction to Landscape Management (HORT 228/TLMT 228) (3 cr)</p>
+<p>AGRO 242 North American Wildland Plants (HORT 242/RNGE 242) (3 cr)</p>
+<p>AGRO 440 Great Plains Ecosystem (NRES 440/RNGE 440) (3 cr)</p>
+<p>BIOS 232 Ecological Issues in the Great Plains (3 cr)</p>
+<p>BIOS 455 Great Plains Flora (3 cr)</p>
+<p>ENVR 201 Science, Systems, Environment, &amp; Sustainability (3 cr)</p>
+<p>GEOG 305 Geography of Agriculture (AGRO 305/HORT 305) (3 cr)</p>
+<p>GEOG 370 Geography of Nebraska (3 cr)</p>
+<p>HORT 495 Grasslands Seminar (AGRO 495/ENTO 495/GRAS 495/NRES 495) (1-2 cr)</p>
+<p>NRES 220 Principles Of Ecology (BIOS 220) (3 cr)</p>
+<p>NRES 310 Introduction to Forest Management (3 cr)</p>
+<p>NRES 452 Climate &amp; Society (AGRO 450/GEOG 450/METR 450) (3 cr)</p>
+<p>C. Great Plains Courses at Large</p>
+<p>Courses can be taken from above categories, in addition to those listed below</p>
+<p>AECN 201 Farm &amp; Ranch Management (4 cr)</p>
+<p>AECN 376 Rural Community Economics (3 cr)</p>
+<p>AECN 456 Environmental Law (NREE 456) (3 cr)</p>
+<p>AECN 457 Water Law (NREE 457/WATS 457) (3 cr)</p>
+<p>AGRO 240 Forage Crop &amp; Pasture Management (RNGE 240) (3 cr)</p>
+<p>AGRO 326 Landscape Solutions (HORT 326/TLMT 326) (3 cr)</p>
+<p>AGRO 442 Wildland Plants (RNGE 442/NRES 442) (3 cr)</p>
+<p>ANTH 290/490 Fieldwork in Anthropology (1-6 cr)</p>
+<p>ANTH 433 North American Archeology (3 cr)</p>
+<p>ANTH 454 Ethnographic Fieldschool (Great Plains Sections) (1-6 cr)</p>
+<p>BIOS 470 Prairie Ecology (Cedar Point) (4 cr)</p>
+<p>BIOS 475 Ornithology (Cedar Point) (3 cr)</p>
+<p>BIOS 476 Mammalogy (NRES 476) (4 cr)</p>
+<p>BIOS 482 Field Entomology (Cedar Point) (ENTO 411) (4 cr)</p>
+<p>BIOS 487 Field Parasitology (Cedar Point) (4 cr)</p>
+<p>BIOS 488 Natural History of the Invertebrates (Cedar Point) (4 cr)</p>
+<p>BIOS 489 Ichthyology (Cedar Point) (NRES 489) (4 cr)</p>
+<p>ENGL 261 American Literature Since 1865 (3 cr)</p>
+<p>ENGL 345N Native American Women Writers (ETHN 345N/WMNS 345N) (3 cr)</p>
+<p>ENVR 319 Environmental Engagement &amp; the Community (2 cr)</p>
+<p>GEOG 271 Geography of the U.S. (3 cr)</p>
+<p>GEOL 457 Ecosystem Ecology (BIOS 457) (4 cr)</p>
+<p>GEOG 467 Great Plains Field Pedology (AGRO 477/NRES 477/SOIL 477) (4 cr)</p>
+<p>GPSP 495 Great Plains Internship (1-6 cr)</p>
+<p>HIST 244 19<sup>th</sup> Century America (3 cr)</p>
+<p>HIST 247 African-American History After 1877 (ETHN 247) (3 cr)</p>
+<p>HIST 346 North American Environmental History (3 cr)</p>
+<p>HIST 363 History of Women &amp; Gender in the American West (WMNS 363) (3 cr)</p>
+<p>HIST 464 Native American History-Selected Topics (ETHN 464) (3 cr)</p>
+<p>NRES 417 Agroforestry Systems in Sustainable Agriculture (HORT 418) (3 cr)</p>
+<p>SOCI 217 Sociology of Race &amp; Ethnicity (ETHN 217) (3 cr)</p>
+<p>SOCI 346 Environmental Sociology (3 cr)</p>
             </div>
         </div>
     </body>


### PR DESCRIPTION
The Advisory Committee for the Center for Great Plains Studies recommends removal of the major based on Coordinating Commission for Post-Secondary Education guidelines for number of majors and the recommendation from the review committee for the Academic Program Review that was conducted in Spring 2016.

Per conversation with the program, the major was made 18 hours instead of 15 to align with other like minors.  The list of courses added under the minor is the same list that it used to refer to under the major. Nothing was added to or removed from this list, with the exception of the independent directed reading and honors course in the Great Plains Studies at-large courses.  Some additional areas where the major was referenced were removed or updated.